### PR TITLE
Fix: Add API v1.3-rev1 compatibility for proxy auto-selection

### DIFF
--- a/cmd/init.go
+++ b/cmd/init.go
@@ -72,7 +72,7 @@ func initApp() {
 		Headers: models.Headers{
 			Accept:      "application/json",
 			ContentType: "application/x-www-form-urlencoded",
-			XAPIVersion: "1.1-rev0",
+			XAPIVersion: "1.3-rev1",
 		},
 		URL:        ":9419/api/oauth2/token",
 		Port:       "9419",

--- a/models/vbrJobsmodels.go
+++ b/models/vbrJobsmodels.go
@@ -70,13 +70,48 @@ type VirtualMachines struct {
 	} `json:"excludes" yaml:"excludes"`
 }
 
+// BackupProxies handles proxy selection for backups
+// Supports both v1.1 (autoSelection) and v1.3+ (autoSelectEnabled) API versions
+type BackupProxies struct {
+	AutoSelection     bool          `json:"autoSelection,omitempty" yaml:"autoSelection,omitempty"`         // v1.1-rev0
+	AutoSelectEnabled bool          `json:"autoSelectEnabled,omitempty" yaml:"autoSelectEnabled,omitempty"` // v1.3-rev1+
+	ProxyIds          []interface{} `json:"proxyIds" yaml:"proxyIds"`
+}
+
+// GetAutoSelect returns the auto-selection value, checking both API version fields
+func (b *BackupProxies) GetAutoSelect() bool {
+	return b.AutoSelection || b.AutoSelectEnabled
+}
+
+// SetAutoSelect sets both fields for maximum compatibility
+func (b *BackupProxies) SetAutoSelect(enabled bool) {
+	b.AutoSelection = enabled
+	b.AutoSelectEnabled = enabled
+}
+
+// GuestInteractionProxies handles proxy selection for guest processing
+// Supports both v1.1 (autoSelection) and v1.3+ (autoSelectEnabled) API versions
+type GuestInteractionProxies struct {
+	AutoSelection     bool          `json:"autoSelection,omitempty" yaml:"autoSelection,omitempty"`         // v1.1-rev0
+	AutoSelectEnabled bool          `json:"autoSelectEnabled,omitempty" yaml:"autoSelectEnabled,omitempty"` // v1.3-rev1+
+	ProxyIds          []interface{} `json:"proxyIds" yaml:"proxyIds"`
+}
+
+// GetAutoSelect returns the auto-selection value, checking both API version fields
+func (g *GuestInteractionProxies) GetAutoSelect() bool {
+	return g.AutoSelection || g.AutoSelectEnabled
+}
+
+// SetAutoSelect sets both fields for maximum compatibility
+func (g *GuestInteractionProxies) SetAutoSelect(enabled bool) {
+	g.AutoSelection = enabled
+	g.AutoSelectEnabled = enabled
+}
+
 type Storage struct {
-	BackupRepositoryID string `json:"backupRepositoryId" yaml:"backupRepositoryId"`
-	BackupProxies      struct {
-		AutoSelection bool          `json:"autoSelection" yaml:"autoSelection"`
-		ProxyIds      []interface{} `json:"proxyIds" yaml:"proxyIds"`
-	} `json:"backupProxies" yaml:"backupProxies"`
-	RetentionPolicy struct {
+	BackupRepositoryID string        `json:"backupRepositoryId" yaml:"backupRepositoryId"`
+	BackupProxies      BackupProxies `json:"backupProxies" yaml:"backupProxies"`
+	RetentionPolicy    struct {
 		Type     string `json:"type" yaml:"type"`
 		Quantity int    `json:"quantity" yaml:"quantity"`
 	} `json:"retentionPolicy" yaml:"retentionPolicy"`
@@ -258,11 +293,8 @@ type GuestProcessing struct {
 		IsEnabled        bool          `json:"isEnabled" yaml:"isEnabled"`
 		IndexingSettings []interface{} `json:"indexingSettings" yaml:"indexingSettings"`
 	} `json:"guestFSIndexing" yaml:"guestFSIndexing"`
-	GuestInteractionProxies struct {
-		AutoSelection bool          `json:"autoSelection" yaml:"autoSelection"`
-		ProxyIds      []interface{} `json:"proxyIds" yaml:"proxyIds"`
-	} `json:"guestInteractionProxies" yaml:"guestInteractionProxies"`
-	GuestCredentials struct {
+	GuestInteractionProxies GuestInteractionProxies `json:"guestInteractionProxies" yaml:"guestInteractionProxies"`
+	GuestCredentials        struct {
 		CredsType             string        `json:"credsType" yaml:"credsType"`
 		CredsID               string        `json:"credsId" yaml:"credsId"`
 		CredentialsPerMachine []interface{} `json:"credentialsPerMachine" yaml:"credentialsPerMachine"`

--- a/resources/vbr_job.go
+++ b/resources/vbr_job.go
@@ -286,7 +286,7 @@ func (r *VBRJobResource) toVBRFormat() (*models.VbrJobPost, error) {
 	vbrJob.Storage.BackupRepositoryID = repoID
 
 	// Set storage defaults
-	vbrJob.Storage.BackupProxies.AutoSelection = true
+	vbrJob.Storage.BackupProxies.SetAutoSelect(true)
 	vbrJob.Storage.RetentionPolicy.Type = "Days"
 	vbrJob.Storage.RetentionPolicy.Quantity = 7
 


### PR DESCRIPTION
## Overview

Adds backward-compatible support for VBR API v1.3-rev1 breaking changes while maintaining compatibility with v1.1-rev0.

Fixes #10

## Problem

VBR API evolved from v1.1-rev0 to v1.3-rev1 with breaking field name changes:
- `autoSelection` (v1.1) → `autoSelectEnabled` (v1.3+)

This affected:
- `BackupProxies` struct in storage configuration
- `GuestInteractionProxies` struct in guest processing configuration

Without this fix, the declarative commands (export/apply/plan/diff) would:
- Fail to read the new field from v1.3 servers
- Send the old field which v1.3 ignores (defaults to false)
- Show false drift in plan/diff operations

## Solution

### Dual-Field Compatibility Approach

Extracted proxy structs into named types with dual fields:

```go
type BackupProxies struct {
    AutoSelection     bool `json:"autoSelection,omitempty"`     // v1.1
    AutoSelectEnabled bool `json:"autoSelectEnabled,omitempty"` // v1.3+
    ProxyIds          []interface{}
}

func (b *BackupProxies) GetAutoSelect() bool {
    return b.AutoSelection || b.AutoSelectEnabled
}

func (b *BackupProxies) SetAutoSelect(enabled bool) {
    b.AutoSelection = enabled
    b.AutoSelectEnabled = enabled
}
```

Same pattern applied to `GuestInteractionProxies`.

### Benefits

1. **Backward compatible**: Works with both v1.1 and v1.3+ servers
2. **Forward compatible**: JSON unmarshaling picks up whichever field the server sends
3. **Write compatibility**: SetAutoSelect() sets both fields, ensuring correct behavior on any API version
4. **No breaking changes**: Existing code continues to work via helper methods

## Changes

### Files Modified

1. **models/vbrJobsmodels.go**
   - Extracted `BackupProxies` into standalone type
   - Extracted `GuestInteractionProxies` into standalone type
   - Added dual-field support with helper methods
   - Added documentation explaining version compatibility

2. **cmd/init.go**
   - Updated default VBR API version from `1.1-rev0` to `1.3-rev1`

3. **resources/vbr_job.go**
   - Updated to use `SetAutoSelect()` helper instead of direct field access

## Testing

- ✅ Code compiles successfully
- ✅ No direct field access remaining in codebase
- ✅ Helper methods ensure both fields are set on write
- ✅ Helper methods check both fields on read

## Impact

This fix is critical for the declarative job management feature (#9) to work correctly with current VBR servers. Without it:
- Jobs could be created with incorrect proxy settings
- Export would fail to capture current configuration
- Plan/diff would show false drift

## Related Issues

- Closes #10
- Related to #3 (Declarative Job Management MVP)
- Should be included in v0.9.0-beta1 release