### PR TITLE
Phase 2: VBR Job Management via API

### DIFF
--- a/cmd/export.go
+++ b/cmd/export.go
@@ -5,6 +5,7 @@ import (
 	"log"
 	"os"
 	"path/filepath"
+	"reflect"
 	"regexp"
 	"strings"
 
@@ -409,6 +410,9 @@ func calculateDiff(base, job map[string]interface{}) map[string]interface{} {
 }
 
 // extractCommonFields extracts commonly changed fields when no base provided
+// This is intentionally minimal - it only extracts the most frequently modified fields
+// (description, retention policy, and daily schedule). If you need more fields in the
+// overlay, provide a base template with --base to get a full diff calculation.
 func extractCommonFields(job map[string]interface{}) map[string]interface{} {
 	overlay := make(map[string]interface{})
 
@@ -440,10 +444,7 @@ func extractCommonFields(job map[string]interface{}) map[string]interface{} {
 
 // deepEqual compares two values for deep equality
 func deepEqual(a, b interface{}) bool {
-	// Simple comparison for now - could be enhanced
-	aBytes, _ := yaml.Marshal(a)
-	bBytes, _ := yaml.Marshal(b)
-	return string(aBytes) == string(bBytes)
+	return reflect.DeepEqual(a, b)
 }
 
 func sanitizeFilename(name string) string {


### PR DESCRIPTION
## Overview

Implements Phase 2 of the Configuration Overlay System: VBR job creation and update via REST API, plus export-as-overlay functionality.

## Features

### 1. Job Creation & Update (`vcli job apply`)
- ✅ **Create jobs** (POST /api/v1/jobs) - Creates new VBR backup jobs from base + overlay
- ✅ **Update jobs** (PUT /api/v1/jobs/{id}) - Updates existing jobs with overlays
- ✅ **Smart detection** - Automatically detects if job exists by name and creates or updates
- ✅ **Full overlay support** - Works with all overlay patterns (production, development, staging)

### 2. Export as Overlay (`vcli export --as-overlay`)
- ✅ **Minimal overlays** - Export 10-30 line patches instead of 300+ line configs
- ✅ **Diff mode** - Calculate differences from base template
- ✅ **GitOps friendly** - Small, reviewable overlay files
- ✅ **Two modes**:
  - Without base: extracts common fields (description, retention, schedule)
  - With base: calculates diff and exports only changed fields

## Implementation Details

### VBR API Compatibility
- Job ID required in BOTH URL and request body for PUT (critical fix)
- `useAgentManagementCredentials` must always be included (no omitempty)
- Credentials object supports both v1.1 and v1.3 formats
- Invalid excludes.disks entries cleaned automatically
- Job name from metadata.name (authoritative source)

### Code Changes
- `cmd/apply.go` (+195 lines): Complete job creation/update with merge logic
- `models/vbrJobsmodels.go` (+8 lines): v1.3 API compatibility
- `cmd/export.go` (+164 lines): Export as overlay functionality

## Testing

**Job Creation:**
```bash
./vcli job apply base-backup.yaml -o overlays/production.yaml
# Creating new job: Test-Job-Create-Phase2
# Created job with ID: d8e7ba91-df1c-4aa8-954c-74c29c91bf20
```

**Job Update:**
```bash
./vcli job apply base-backup.yaml -o overlays/development.yaml
# Job 'Backup Job 1' already exists (ID: c07c7ea3-0471-43a6-af57-c03c0d82354a), updating...
# Updated job: Backup Job 1
```

**Export as Overlay:**
```bash
./vcli export c07c7ea3-0471-43a6-af57-c03c0d82354a --as-overlay --base base.yaml -o overlay.yaml
# Exported job to overlay.yaml (only changed fields)
```

All features tested against live VBR v13.0 (API v1.3-rev1).

## Resolves

- Closes #19 (vcli job export --as-overlay)
- Partial completion of #12 (Phase 2 epic)

## Next Steps

Phase 2 remaining work (will be separate PR):
- #18: Drift detection (`vcli job diff`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)