### PR TITLE
Add scale-out backup repository state management and drift detection

### DIFF
--- a/cmd/drift.go
+++ b/cmd/drift.go
@@ -45,6 +45,26 @@ var repoCriticalPaths = map[string]bool{
 	"type": true,
 }
 
+// sobrIgnoreFields defines read-only or frequently changing fields to ignore during SOBR drift detection
+var sobrIgnoreFields = map[string]bool{
+	"id":       true,
+	"uniqueId": true,
+	"status":   true,
+}
+
+// sobrCriticalPaths defines field paths flagged as CRITICAL severity for SOBR drift
+var sobrCriticalPaths = map[string]bool{
+	"isEnabled":                      true,
+	"immutabilityMode":               true,
+	"daysCount":                      true,
+	"movePolicyEnabled":              true,
+	"copyPolicyEnabled":              true,
+	"performanceExtents":             true,
+	"extents":                        true,
+	"type":                           true,
+	"enforceStrictPlacementPolicy":   true,
+}
+
 // detectDrift compares state spec against live VBR config, ignoring specified fields
 func detectDrift(stateSpec, vbrMap map[string]interface{}, ignore map[string]bool) []Drift {
 	var drifts []Drift

--- a/models/vbrSobrModels.go
+++ b/models/vbrSobrModels.go
@@ -1,0 +1,21 @@
+package models
+
+// VbrSobrGet represents a scale-out backup repository from the VBR API.
+// Only common fields are typed; the full response is compared as map[string]interface{}
+// for drift detection since tier configurations vary.
+type VbrSobrGet struct {
+	ID              string                 `json:"id" yaml:"id"`
+	Name            string                 `json:"name" yaml:"name"`
+	Description     string                 `json:"description" yaml:"description"`
+	UniqueID        string                 `json:"uniqueId" yaml:"uniqueId"`
+	PerformanceTier map[string]interface{} `json:"performanceTier,omitempty" yaml:"performanceTier,omitempty"`
+	CapacityTier    map[string]interface{} `json:"capacityTier,omitempty" yaml:"capacityTier,omitempty"`
+	ArchiveTier     map[string]interface{} `json:"archiveTier,omitempty" yaml:"archiveTier,omitempty"`
+	PlacementPolicy map[string]interface{} `json:"placementPolicy,omitempty" yaml:"placementPolicy,omitempty"`
+}
+
+// VbrSobrList represents the list response from the scale-out repositories endpoint
+type VbrSobrList struct {
+	Data       []VbrSobrGet           `json:"data"`
+	Pagination map[string]interface{} `json:"pagination,omitempty"`
+}


### PR DESCRIPTION
## Summary
- Adds `vcli repo sobr-snapshot` and `vcli repo sobr-diff` subcommands for capturing and detecting drift in VBR scale-out backup repository (SOBR) configuration
- Tracks extent membership, capacity tier settings, placement policy, and archive tier config as `VBRScaleOutRepository` state resources
- Adds SOBR-specific critical paths (extent changes, capacity tier immutability, placement policy) for severity-annotated drift output
- Refactors `saveRepoToState` into shared `saveResourceToState` helper to reduce duplication

Closes #25

## Test plan
- [x] `vcli repo sobr-snapshot "Scale-out Backup Repository 1"` — stores SOBR in state
- [x] `vcli repo sobr-diff "Scale-out Backup Repository 1"` — no drift immediately after snapshot (exit 0)
- [x] `vcli repo sobr-snapshot --all` / `vcli repo sobr-diff --all` — bulk variants work
- [x] `vcli repo diff --all` — existing repo drift unaffected (6 repos clean)
- [x] `vcli job diff --all` — existing job drift unaffected (1 job clean)
- [x] All tested against live VBR environment at 192.168.0.149

🤖 Generated with [Claude Code](https://claude.com/claude-code)