### PR TITLE
Add security severity classification to drift output

### DIFF
--- a/cmd/drift.go
+++ b/cmd/drift.go
@@ -160,7 +160,7 @@ var jobSeverityMap = SeverityMap{
 
 // repoSeverityMap classifies repository drift fields by severity
 var repoSeverityMap = SeverityMap{
-	// CRITICAL — repository type or immutability changes
+	// CRITICAL — repository type changes
 	"type": SeverityCritical,
 	// WARNING — operational changes with security relevance
 	"path":         SeverityWarning,
@@ -320,6 +320,14 @@ func exitCodeForDrifts(drifts []Drift) int {
 		return 4
 	}
 	return 3
+}
+
+// noDriftMessage returns the appropriate "no drift" message, accounting for severity filtering
+func noDriftMessage(resourceDesc string, minSev Severity) string {
+	if minSev != SeverityInfo {
+		return fmt.Sprintf("No %s or higher drift detected. %s (lower severity drifts may exist.)", minSev, resourceDesc)
+	}
+	return fmt.Sprintf("No drift detected. %s", resourceDesc)
 }
 
 // --- Drift printing ---

--- a/cmd/encryption.go
+++ b/cmd/encryption.go
@@ -248,7 +248,7 @@ func diffSingleEncryptionPassword(hint string) {
 	drifts = filterDriftsBySeverity(drifts, minSev)
 
 	if len(drifts) == 0 {
-		fmt.Println("No drift detected. Encryption password matches snapshot state.")
+		fmt.Println(noDriftMessage("Encryption password matches snapshot state.", minSev))
 		os.Exit(0)
 	}
 
@@ -562,7 +562,7 @@ func diffSingleKmsServer(name string) {
 	drifts = filterDriftsBySeverity(drifts, minSev)
 
 	if len(drifts) == 0 {
-		fmt.Println("No drift detected. KMS server matches snapshot state.")
+		fmt.Println(noDriftMessage("KMS server matches snapshot state.", minSev))
 		os.Exit(0)
 	}
 

--- a/cmd/jobs.go
+++ b/cmd/jobs.go
@@ -379,7 +379,7 @@ func diffSingleJob(jobName string) {
 	drifts = filterDriftsBySeverity(drifts, minSev)
 
 	if len(drifts) == 0 {
-		fmt.Println("No drift detected. Job matches applied state.")
+		fmt.Println(noDriftMessage("Job matches applied state.", minSev))
 		os.Exit(0)
 	}
 

--- a/cmd/repo.go
+++ b/cmd/repo.go
@@ -206,7 +206,7 @@ func diffSingleRepo(repoName string) {
 	drifts = filterDriftsBySeverity(drifts, minSev)
 
 	if len(drifts) == 0 {
-		fmt.Println("No drift detected. Repository matches snapshot state.")
+		fmt.Println(noDriftMessage("Repository matches snapshot state.", minSev))
 		os.Exit(0)
 	}
 
@@ -444,7 +444,7 @@ func diffSingleSobr(sobrName string) {
 	drifts = filterDriftsBySeverity(drifts, minSev)
 
 	if len(drifts) == 0 {
-		fmt.Println("No drift detected. Scale-out repository matches snapshot state.")
+		fmt.Println(noDriftMessage("Scale-out repository matches snapshot state.", minSev))
 		os.Exit(0)
 	}
 

--- a/cmd/severity_config.go
+++ b/cmd/severity_config.go
@@ -36,10 +36,10 @@ func loadSeverityOverrides() {
 	if severityOverridesLoaded {
 		return
 	}
-	severityOverridesLoaded = true
 
 	configPath := findSeverityConfig()
 	if configPath == "" {
+		severityOverridesLoaded = true
 		return
 	}
 
@@ -59,6 +59,8 @@ func loadSeverityOverrides() {
 	applySeverityOverrides(config.Sobr, sobrSeverityMap)
 	applySeverityOverrides(config.Encryption, encryptionSeverityMap)
 	applySeverityOverrides(config.Kms, kmsSeverityMap)
+
+	severityOverridesLoaded = true
 }
 
 func findSeverityConfig() string {
@@ -89,6 +91,8 @@ func applySeverityOverrides(overrides map[string]string, sm SeverityMap) {
 		switch severity {
 		case SeverityCritical, SeverityWarning, SeverityInfo:
 			sm[field] = severity
+		default:
+			fmt.Fprintf(os.Stderr, "Warning: Unknown severity %q for field %q (use CRITICAL, WARNING, or INFO)\n", sev, field)
 		}
 	}
 }


### PR DESCRIPTION
## Summary
- Replaces binary CRITICAL/non-critical system with three-tier severity: CRITICAL, WARNING, INFO
- Adds `--severity` flag to all diff commands (filter by minimum severity level)
- Adds `--security-only` flag as alias for `--severity warning`
- Exit code 4 for CRITICAL drift, 3 for WARNING/INFO, 0 for clean
- Severity classification is configurable via `severity-config.json` in `~/.vcli/` or `VCLI_SETTINGS_PATH`
- Per-resource severity maps define which fields are CRITICAL/WARNING/INFO

## Files Changed
- `cmd/drift.go` — Core severity system: `Severity` type, `SeverityMap`, classify/filter/exit-code helpers, per-resource severity maps
- `cmd/severity_config.go` — New: loads optional `severity-config.json` to override built-in classifications
- `cmd/jobs.go` — Updated job diff with severity classification, filtering, and new exit codes
- `cmd/repo.go` — Updated repo and SOBR diff with severity classification
- `cmd/encryption.go` — Updated encryption and KMS diff with severity classification

## Severity Classifications

| Resource | CRITICAL | WARNING |
|----------|----------|---------|
| Job | isDisabled, retentionPolicy, gfsPolicy, backupRepositoryId | guestProcessing, schedule, encryption, healthCheck |
| Repository | type | path, maxTaskCount |
| SOBR | isEnabled, immutabilityMode, type, enforceStrictPlacementPolicy | movePolicyEnabled, copyPolicyEnabled, daysCount |
| Encryption | (removal) | hint |
| KMS | type, (removal) | description |

## Test plan
- [x] Build succeeds with no errors
- [x] `vcli repo diff --all` — 6 repos clean
- [x] `vcli repo sobr-diff --all` — 1 SOBR clean
- [x] `vcli job diff --all` — 1 job clean
- [x] `vcli encryption diff --all` — handles empty state
- [x] `vcli job diff --help` shows --severity and --security-only flags
- [x] `--severity critical` flag filters correctly
- [x] `--security-only` flag works as alias
- [x] Invalid severity value exits with error and code 1

Closes #27

🤖 Generated with [Claude Code](https://claude.com/claude-code)