### PR TITLE
Add job snapshot command to capture existing jobs into state

### DIFF
--- a/cmd/jobs.go
+++ b/cmd/jobs.go
@@ -557,10 +557,7 @@ func snapshotSingleJob(jobName string) {
 	}
 
 	// Fetch all jobs and find by name
-	type JobsResponse struct {
-		Data []models.VbrJobGet `json:"data"`
-	}
-	jobList := vhttp.GetData[JobsResponse]("jobs", profile)
+	jobList := vhttp.GetData[models.VbrJobList]("jobs", profile)
 
 	var found *models.VbrJobGet
 	for i := range jobList.Data {
@@ -594,10 +591,7 @@ func snapshotAllJobs() {
 		log.Fatal("This command only works with VBR at the moment.")
 	}
 
-	type JobsResponse struct {
-		Data []models.VbrJobGet `json:"data"`
-	}
-	jobList := vhttp.GetData[JobsResponse]("jobs", profile)
+	jobList := vhttp.GetData[models.VbrJobList]("jobs", profile)
 
 	if len(jobList.Data) == 0 {
 		fmt.Println("No jobs found.")

--- a/models/vbrJobsmodels.go
+++ b/models/vbrJobsmodels.go
@@ -33,6 +33,12 @@ type VbrJobGet struct {
 	IsDisabled      bool            `json:"isDisabled" yaml:"isDisabled"`
 }
 
+// VbrJobList represents the list response from the jobs endpoint
+type VbrJobList struct {
+	Data       []VbrJobGet            `json:"data"`
+	Pagination map[string]interface{} `json:"pagination,omitempty"`
+}
+
 // Includes represents a VM or object included in a backup job
 // Structure matches VBR API v1.3 GET response (flat, no inventoryObject wrapper)
 type Includes struct {


### PR DESCRIPTION
## Summary

Implements the missing `vcli job snapshot` command, completing parity with other resource types (repositories, SOBRs, encryption passwords, KMS servers).

Closes #83

## New Commands

```bash
# Snapshot a single job by name
vcli job snapshot "Backup Job 1"

# Snapshot all jobs
vcli job snapshot --all
```

## Behavior

- Fetches current job configuration from VBR API
- Saves to state with `origin: "observed"`
- Enables drift detection via `vcli job diff`
- Does **not** enable remediation via `vcli job apply` (use `adopt` for active management)

## Use Cases

### 1. Track Jobs Created Manually in VBR
Monitor drift for jobs created outside of vcli without modifying them.

### 2. Gradual vcli Adoption
```bash
# Snapshot all existing jobs for monitoring
vcli job snapshot --all

# Apply only critical production jobs from YAML
vcli job apply prod-db-job.yaml
vcli job apply prod-app-job.yaml

# Diff shows which jobs have drifted
vcli job diff --all --security-only
```

### 3. CI/CD Drift Monitoring
```bash
vcli job snapshot --all
vcli job diff --all --security-only
if [ $? -eq 4 ]; then
  echo "CRITICAL drift detected!"
  # Alert security team
fi
```

## Implementation

Follows the proven pattern from `cmd/repo.go`:

- `snapshotSingleJob()` - Fetches and saves single job
- `snapshotAllJobs()` - Iterates and snapshots all jobs
- `saveJobToState()` - Helper that calls `saveResourceToState("VBRJob", ...)`
- Reuses existing `saveResourceToState()` infrastructure

## Testing

Tested on live VBR environment (192.168.0.149):

### ✅ Snapshot Single Job
```bash
$ vcli job snapshot "Backup Job 1"
Snapshot saved for job: Backup Job 1
```

### ✅ Snapshot All Jobs
```bash
$ vcli job snapshot --all
Snapshotting 3 jobs...
  Snapshot saved: Backup Job 1
  Snapshot saved: Test-From-Exported-Overlay
  Snapshot saved: Test-Job-Create-Phase2

State updated: /Users/edwardhoward/.vcli/state.json
```

### ✅ State Shows Correct Origin
```bash
$ cat ~/.vcli/state.json | jq '.resources."Backup Job 1".origin'
"observed"
```

### ✅ Drift Detection Works
```bash
$ vcli job diff "Backup Job 1"
Checking drift for job: Backup Job 1 (observed)

Drift detected:
  INFO ~ storage.advancedSettings.activeFulls.monthly.dayOfMonth: Removed from VBR
  ...
  
Summary:
  - 31 drifts detected
  - Highest severity: INFO
  - Last snapshot: 2026-02-05 14:41:51
  - Last snapshot by: edwardhoward

This resource is monitored only. To enable remediation:
  1. Export: vcli job export "Backup Job 1" -o jobs/backup-job-1.yaml
  2. Adopt:  vcli job adopt jobs/backup-job-1.yaml
```

### ✅ Exit Code Correct
- Exit code 3 for INFO-level drift (expected)

## Files Changed

- `cmd/jobs.go` (+122 lines)
  - Added `snapshotSingleJob()` function
  - Added `snapshotAllJobs()` function
  - Added `saveJobToState()` helper
  - Added `snapshotCmd` Cobra command with `--all` flag
  - Registered command in `init()`

## Consistency

This completes the snapshot command matrix:

| Resource | Snapshot Command | ✅ |
|----------|------------------|-----|
| Jobs | `vcli job snapshot` | ✅ (this PR) |
| Repositories | `vcli repo snapshot` | ✅ |
| SOBRs | `vcli repo sobr-snapshot` | ✅ |
| Encryption Passwords | `vcli encryption snapshot` | ✅ |
| KMS Servers | `vcli encryption kms-snapshot` | ✅ |

All resource types now support full observability without requiring active management.