### PR TITLE
Fix job diff to use raw JSON instead of typed struct

### DIFF
--- a/cmd/jobs.go
+++ b/cmd/jobs.go
@@ -402,18 +402,13 @@ func diffSingleJob(jobName string) {
 	}
 	fmt.Printf("Checking drift for job: %s%s\n\n", jobName, originLabel)
 
-	// Fetch current from VBR
+	// Fetch current from VBR as raw JSON (matches snapshot storage format)
 	endpoint := fmt.Sprintf("jobs/%s", resource.ID)
-	current := vhttp.GetData[models.VbrJobGet](endpoint, profile)
+	currentRaw := vhttp.GetData[json.RawMessage](endpoint, profile)
 
-	// Convert current job to map for comparison
-	currentBytes, err := json.Marshal(current)
-	if err != nil {
-		log.Fatalf("Failed to marshal current job for drift detection: %v", err)
-	}
 	var currentMap map[string]interface{}
-	if err := json.Unmarshal(currentBytes, &currentMap); err != nil {
-		log.Fatalf("Failed to unmarshal current job into map for drift detection: %v", err)
+	if err := json.Unmarshal(currentRaw, &currentMap); err != nil {
+		log.Fatalf("Failed to unmarshal current job data: %v", err)
 	}
 
 	// Compare, classify, enhance, filter
@@ -482,18 +477,12 @@ func diffAllJobs() {
 	var allDrifts []Drift
 
 	for _, resource := range resources {
-		// Fetch current from VBR
+		// Fetch current from VBR as raw JSON (matches snapshot storage format)
 		endpoint := fmt.Sprintf("jobs/%s", resource.ID)
-		current := vhttp.GetData[models.VbrJobGet](endpoint, profile)
+		currentRaw := vhttp.GetData[json.RawMessage](endpoint, profile)
 
-		// Convert to map for comparison
-		currentBytes, err := json.Marshal(current)
-		if err != nil {
-			fmt.Printf("  %s: Failed to marshal job data: %v\n", resource.Name, err)
-			continue
-		}
 		var currentMap map[string]interface{}
-		if err := json.Unmarshal(currentBytes, &currentMap); err != nil {
+		if err := json.Unmarshal(currentRaw, &currentMap); err != nil {
 			fmt.Printf("  %s: Failed to unmarshal job data: %v\n", resource.Name, err)
 			continue
 		}


### PR DESCRIPTION
## Summary

- Fix job diff false positives caused by deserializing VBR API responses through `models.VbrJobGet` struct instead of using raw JSON directly
- Aligns job diff with every other resource type (repos, SOBRs, encryption, KMS) which already use `json.RawMessage`

## Problem

`vcli job snapshot` stores raw API JSON, but `vcli job diff` deserialized into a typed Go struct then re-marshaled for comparison. This round-trip caused ~31 false-positive INFO drifts per job immediately after snapshotting, due to:

- Field name mismatches (`dayOfMonth` vs `dayOfMonths`, `processedVmsCount` vs `limitProcessedVmCount`)
- Fields not in the struct being silently dropped
- Nil/zero-value differences from Go struct initialization

## Fix

Switch `diffSingleJob` and `diffAllJobs` from `vhttp.GetData[models.VbrJobGet]` to `vhttp.GetData[json.RawMessage]`, eliminating the struct round-trip.

## Test plan

- [x] Verified against live VBR environment with 4 jobs
- [x] `vcli job snapshot --all` then `vcli job diff --all` shows 0 drifts (was 31 per job)
- [x] `go build` compiles cleanly
- [x] Verify `vcli job diff <name>` still works for single job
- [x] Verify security-aware severity classification still works after change

Closes #88

🤖 Generated with [Claude Code](https://claude.com/claude-code)