### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,5 +1,8 @@
 name: CI
 
+permissions:
+  contents: read
+
 on:
   push:
     branches: [master]


### PR DESCRIPTION
Potential fix for [https://github.com/shapedthought/owlctl/security/code-scanning/1](https://github.com/shapedthought/owlctl/security/code-scanning/1)

In general, the problem is fixed by explicitly specifying a restrictive `permissions` block for the workflow or for each job, rather than relying on implicit repository/organization defaults. For a simple CI workflow that only checks out code and runs build/test commands, read-only access to repository contents is sufficient.

The best fix here, without changing existing functionality, is to add a `permissions:` section with `contents: read` at the workflow (top) level so it applies to all jobs. This keeps the token limited to read-only access to the repository contents and does not interfere with `actions/checkout`, which needs only read access. Concretely, in `.github/workflows/ci.yml`, insert:

```yaml
permissions:
  contents: read
```

between the `name: CI` and `on:` lines. No additional imports, methods, or other definitions are required because this is purely a configuration change in the workflow YAML.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
