### PR TITLE
Add YAML export for repos, SOBRs, encryption, KMS (#92-#95)

### DIFF
--- a/cmd/export_resource_test.go
+++ b/cmd/export_resource_test.go
@@ -499,22 +499,20 @@ func TestKmsIgnoreFields_StripsCorrectFields(t *testing.T) {
 
 // --- ResourceExportConfig.SupportsOverlay tests ---
 
-func TestExportSingleResource_OverlayBlockedWhenNotSupported(t *testing.T) {
+func TestConvertResourceToYAML_OverlayWithBasePath_ReturnsErrorForBadPath(t *testing.T) {
 	cfg := ResourceExportConfig{
 		Kind:            "VBREncryptionPassword",
 		DisplayName:     "encryption password",
+		IgnoreFields:    map[string]bool{},
 		SupportsOverlay: false,
 	}
 
 	rawJSON := `{"hint": "test"}`
-	_, err := convertResourceToYAML("test", "id-1", cfg, json.RawMessage(rawJSON), true, "/some/base.yaml")
-	// When overlay is not supported but asOverlay=true, the function itself doesn't check —
-	// it's the caller (exportSingleResource) that calls log.Fatal. But we can at least
-	// verify the base-required error path still fires for supported types.
-	// For unsupported types, the check happens at the command level.
-	// So test that supported types with overlay but no base give the right error.
+	// convertResourceToYAML checks for missing base path (returns error),
+	// while the SupportsOverlay check happens at the command level (log.Fatal).
+	_, err := convertResourceToYAML("test", "id-1", cfg, json.RawMessage(rawJSON), true, "/nonexistent/base.yaml")
 	if err == nil {
-		t.Fatal("Expected error for overlay without base")
+		t.Fatal("Expected error for nonexistent base path")
 	}
 }
 

--- a/cmd/repo.go
+++ b/cmd/repo.go
@@ -889,6 +889,7 @@ Examples:
 			PluralName:      "repositories",
 			IgnoreFields:    repoIgnoreFields,
 			FetchSingle:     fetchCurrentRepo,
+			FetchByID:       fetchRepoByID,
 			ListAll:         listAllRepos,
 			SupportsOverlay: true,
 		}
@@ -935,6 +936,7 @@ Examples:
 			PluralName:      "scale-out repositories",
 			IgnoreFields:    sobrIgnoreFields,
 			FetchSingle:     fetchCurrentSobr,
+			FetchByID:       fetchSobrByID,
 			ListAll:         listAllSobrs,
 			SupportsOverlay: true,
 		}
@@ -947,6 +949,20 @@ Examples:
 			log.Fatal("Provide SOBR name or use --all")
 		}
 	},
+}
+
+// fetchRepoByID retrieves a repository by ID (used for bulk export)
+func fetchRepoByID(id string, profile models.Profile) (json.RawMessage, error) {
+	endpoint := fmt.Sprintf("backupInfrastructure/repositories/%s", id)
+	repoData := vhttp.GetData[json.RawMessage](endpoint, profile)
+	return repoData, nil
+}
+
+// fetchSobrByID retrieves a SOBR by ID (used for bulk export)
+func fetchSobrByID(id string, profile models.Profile) (json.RawMessage, error) {
+	endpoint := fmt.Sprintf("backupInfrastructure/scaleOutRepositories/%s", id)
+	sobrData := vhttp.GetData[json.RawMessage](endpoint, profile)
+	return sobrData, nil
 }
 
 // listAllRepos returns all repositories as ResourceListItems


### PR DESCRIPTION
## Summary
- Adds generic export infrastructure in `cmd/export_resource.go` with `ResourceExportConfig` pattern
- Implements `repo export`, `repo sobr-export`, `encryption export`, and `encryption kms-export` commands
- Each supports single resource export, bulk export (`--all -d`), and overlay generation (`--as-overlay --base`) where applicable
- Encryption export defensively strips password/secret fields and disables overlay mode (read-only inventory resource)
- Reuses existing `fetchCurrent*` functions and ignore fields from drift detection
- 22 unit tests covering YAML conversion, ignore field stripping, overlay diffing, sanitization, and round-trip parsing
- Verified against live VBR test environment (7 repos, 1 SOBR, 1 encryption password, 1 KMS server)

## Test plan
- [x] `go build` succeeds
- [x] `go test ./...` passes (22 new tests + all existing)
- [x] `repo export` single + `--all` verified against live VBR
- [x] `repo export --as-overlay --base` produces correct diff
- [x] `repo sobr-export --all` verified against live VBR
- [x] `encryption export --all` verified — no password values in output
- [x] `encryption kms-export --all` verified against live VBR
- [x] Exported YAML is valid and parseable by `resources.LoadResourceSpec`

🤖 Generated with [Claude Code](https://claude.com/claude-code)