### PR TITLE
Fix repeated authentication on Windows

### DIFF
--- a/config/instance.go
+++ b/config/instance.go
@@ -60,12 +60,13 @@ func ResolveInstance(cfg *VCLIConfig, name string) (*ResolvedInstance, error) {
 // ActivateInstance sets process-global state so that existing vhttp/auth code
 // picks up this instance's connection parameters without any call-site changes.
 //
-// It does four things:
-//  1. Sets OWLCTL_URL, OWLCTL_USERNAME, OWLCTL_PASSWORD env vars
-//  2. Sets OWLCTL_KEYCHAIN_KEY so token_manager stores/retrieves per-instance tokens
-//  3. Overrides utils.ReadSettings() to return the instance's product as SelectedProfile
+// It does five things:
+//  1. Clears the in-process token cache (previous instance's token must not be reused)
+//  2. Sets OWLCTL_URL, OWLCTL_USERNAME, OWLCTL_PASSWORD env vars
+//  3. Sets OWLCTL_KEYCHAIN_KEY so token_manager stores/retrieves per-instance tokens
+//  4. Overrides the profile port if the instance specifies a non-default port
+//  5. Overrides utils.ReadSettings() to return the instance's product as SelectedProfile
 //     and the instance's insecure flag as ApiNotSecure
-//  4. Returns nil on success
 func ActivateInstance(resolved *ResolvedInstance) error {
 	// 0. Clear in-process token cache since we're switching instances
 	auth.ClearProcessTokenCache()


### PR DESCRIPTION
## Summary
- Windows Credential Manager rejects large VBR JWT tokens (>2560 byte blob limit), causing keychain storage to fail with "The sub received bad data"
- Without caching, every API call within a single command re-authenticates against the VBR server
- Adds an in-process token cache so the first successful auth is reused for all subsequent API requests in the same process
- Clears the cache on instance switch (`ActivateInstance`) to ensure correct tokens per server

## Test plan
- [ ] Verify on Windows: `owlctl get jobs` only triggers one login in VBR server logs
- [ ] Verify bulk operations (`export --all`) only authenticate once
- [ ] Verify `--instance` flag still works (cache cleared on switch)
- [ ] Verify existing tests pass (`go test ./...`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)