### PR TITLE
Fix repo/SOBR/KMS apply failing with 'Id must not be empty'

### DIFF
--- a/cmd/apply.go
+++ b/cmd/apply.go
@@ -409,14 +409,6 @@ func fetchCurrentJob(name string, profile models.Profile) (json.RawMessage, stri
 // This handles guest credential defaults and VM exclude cleanup using map-based operations,
 // making it safe for all job types (VM, file, NAS, etc.).
 func prepareJobPayload(spec, existing map[string]interface{}) (map[string]interface{}, error) {
-	// VBR jobs API requires the ID in PUT body. cleanSpec strips it (it's in jobIgnoreFields
-	// for drift detection), so we restore it from the existing resource when updating.
-	if existing != nil {
-		if id, ok := existing["id"]; ok {
-			spec["id"] = id
-		}
-	}
-
 	// Guest credential defaults: if no credsType and no credentials, set useAgentManagementCredentials
 	if gp, ok := spec["guestProcessing"].(map[string]interface{}); ok {
 		if gc, ok := gp["guestCredentials"].(map[string]interface{}); ok {

--- a/cmd/apply_resource.go
+++ b/cmd/apply_resource.go
@@ -192,6 +192,12 @@ func applyResourceSpec(spec resources.ResourceSpec, cfg ResourceApplyConfig, pro
 		// Restore existing values for skipped fields (don't change them)
 		mergedSpec = restoreSkippedFields(mergedSpec, existingMap, toSkip)
 
+		// VBR API requires the id field in PUT request bodies. cleanSpec strips it
+		// (it's in IgnoreFields for drift/export), so restore it from the existing resource.
+		if id, ok := existingMap["id"]; ok {
+			mergedSpec["id"] = id
+		}
+
 		// Apply payload transformation if defined
 		if cfg.PreparePayload != nil {
 			mergedSpec, err = cfg.PreparePayload(mergedSpec, existingMap)


### PR DESCRIPTION
## Summary

Fixes #139 — `owlctl repo apply` (and SOBR/KMS apply) fails with HTTP 400 because the VBR API requires the `id` field in PUT request bodies, but `cleanSpec` strips it since it's in `IgnoreFields`.

## Changes

- **apply_resource.go**: Added generic `id` injection from the existing resource into the merged spec before PUT. This runs for all resource types.
- **apply.go**: Removed the now-redundant job-specific `id` injection from `prepareJobPayload`.

## Root Cause

The `id` field was only being restored in `prepareJobPayload` (job-specific), so repos, SOBRs, and KMS servers never had it injected back after `cleanSpec` removed it.