### PR TITLE
Fix false change reports for numeric fields in apply

### DIFF
--- a/cmd/apply_reporting.go
+++ b/cmd/apply_reporting.go
@@ -78,7 +78,9 @@ func computeChangesRecursive(prefix string, existing, desired map[string]interfa
 	}
 }
 
-// applyValuesEqual compares two values for equality
+// applyValuesEqual compares two values for equality.
+// Handles numeric type mismatches (JSON float64 vs YAML int) by comparing
+// as float64 when both values are numeric.
 func applyValuesEqual(a, b interface{}) bool {
 	// Handle nil cases
 	if a == nil && b == nil {
@@ -88,8 +90,33 @@ func applyValuesEqual(a, b interface{}) bool {
 		return false
 	}
 
+	// Numeric comparison: JSON unmarshals numbers as float64, YAML as int.
+	aNum, aIsNum := tryFloat64(a)
+	bNum, bIsNum := tryFloat64(b)
+	if aIsNum && bIsNum {
+		return aNum == bNum
+	}
+
 	// Use reflect.DeepEqual for complex types
 	return reflect.DeepEqual(a, b)
+}
+
+// tryFloat64 attempts to convert a value to float64 for numeric comparison.
+func tryFloat64(v interface{}) (float64, bool) {
+	switch n := v.(type) {
+	case float64:
+		return n, true
+	case float32:
+		return float64(n), true
+	case int:
+		return float64(n), true
+	case int64:
+		return float64(n), true
+	case int32:
+		return float64(n), true
+	default:
+		return 0, false
+	}
 }
 
 // applyFormatValue formats a value for display


### PR DESCRIPTION
## Summary

Fixes #142 — `apply` commands report fields as changed even when values are identical (e.g. `retryCount: 3 -> 3`).

## Root Cause

`applyValuesEqual()` uses `reflect.DeepEqual`, which does strict type comparison. JSON unmarshals numbers as `float64` (from VBR API), YAML unmarshals as `int` (from spec files). So `float64(3) != int(3)` triggers a false diff.

## Fix

Added numeric type normalization in `applyValuesEqual()` via a `tryFloat64()` helper. When both values are numeric, they're compared as `float64` regardless of their original Go type.

## Affected Commands

All apply commands: `job apply`, `repo apply`, `repo sobr-apply`, `encryption kms-apply`.