### PR TITLE
Add auth package test suite for token storage methods

### DIFF
--- a/auth/authenticator_test.go
+++ b/auth/authenticator_test.go
@@ -125,9 +125,13 @@ func callBasicAuth(t *testing.T, serverURL, username, password string, profile m
 	return &AuthResult{Token: token, ExpiresIn: 3600, TokenType: "session", IsBasicAuth: true}, nil
 }
 
-// ---- OAuth Authentication ------------------------------------------------------
+// ---- OAuth Authentication flow -------------------------------------------------
+// Note: these tests exercise the OAuth/BasicAuth HTTP flows via callOAuth/callBasicAuth
+// helper functions backed by mock servers. They do not call Authenticator.Authenticate
+// directly (which builds https:// URLs incompatible with httptest servers).
+// Coverage of Authenticator.Authenticate itself requires integration tests (#77).
 
-func TestAuthenticator_OAuth_Success(t *testing.T) {
+func TestOAuthFlow_Success(t *testing.T) {
 	srv := newMockOAuthServer(t)
 	defer srv.Close()
 
@@ -156,7 +160,7 @@ func TestAuthenticator_OAuth_Success(t *testing.T) {
 	}
 }
 
-func TestAuthenticator_OAuth_InvalidCredentials(t *testing.T) {
+func TestOAuthFlow_InvalidCredentials(t *testing.T) {
 	srv := newMockOAuthServer(t)
 	defer srv.Close()
 
@@ -175,9 +179,9 @@ func TestAuthenticator_OAuth_InvalidCredentials(t *testing.T) {
 	}
 }
 
-// ---- Basic Auth (Enterprise Manager) ------------------------------------------
+// ---- Basic Auth (Enterprise Manager) flow -------------------------------------
 
-func TestAuthenticator_BasicAuth_Success(t *testing.T) {
+func TestBasicAuthFlow_Success(t *testing.T) {
 	srv := newMockBasicAuthServer(t)
 	defer srv.Close()
 
@@ -199,7 +203,7 @@ func TestAuthenticator_BasicAuth_Success(t *testing.T) {
 	}
 }
 
-func TestAuthenticator_BasicAuth_InvalidCredentials(t *testing.T) {
+func TestBasicAuthFlow_InvalidCredentials(t *testing.T) {
 	srv := newMockBasicAuthServer(t)
 	defer srv.Close()
 

--- a/auth/token_manager_test.go
+++ b/auth/token_manager_test.go
@@ -121,6 +121,12 @@ func TestIsValidTokenFormat(t *testing.T) {
 
 // ---- IsCI / isInteractiveSession -----------------------------------------------
 
+// TestIsCI_KnownCIEnvVars verifies that IsCI returns true when known CI env vars are set.
+// Note: in a `go test` process stdin is not a TTY, so isInteractiveSession() returns false
+// (i.e. IsCI()=true) regardless of env vars. The CI env var detection branch is therefore
+// not directly reachable in unit tests without refactoring isInteractiveSession to accept
+// an injectable isTTY parameter. For now these tests confirm the public API contract:
+// IsCI() is true in any non-TTY environment, which covers all real CI/CD scenarios.
 func TestIsCI_KnownCIEnvVars(t *testing.T) {
 	ciVars := []string{
 		"CI",
@@ -379,6 +385,16 @@ func TestGetToken_KeychainKeyOverrideUsed(t *testing.T) {
 // ---- ClearProcessTokenCache ----------------------------------------------------
 
 func TestClearProcessTokenCache(t *testing.T) {
+	// Capture and restore original state so this test doesn't affect others.
+	origCache := processTokenCache
+	origKey := processTokenCacheKey
+	origExpiry := processTokenExpiresAt
+	t.Cleanup(func() {
+		processTokenCache = origCache
+		processTokenCacheKey = origKey
+		processTokenExpiresAt = origExpiry
+	})
+
 	processTokenCache = "cached-token"
 	processTokenCacheKey = "vbr"
 	processTokenExpiresAt = time.Now().Add(10 * time.Minute)


### PR DESCRIPTION
## Summary

- 34 unit tests covering the `auth` package (previously at 0% coverage)
- Mock keyring implementation for testing without system keychain access
- Mock HTTP servers for OAuth and Basic Auth flow testing

## Coverage

| Function | Coverage |
|---|---|
| `isValidTokenFormat` | 100% |
| `keychainKey` | 100% |
| `IsCI` | 100% |
| `ClearProcessTokenCache` | 100% |
| `DeleteToken` | 100% |
| `FormatTokenForHeaders` | 100% |
| `StoreToken` | 87.5% |
| `getTokenFromKeychain` | 83.3% |
| `ExtractTokenInfo` | 88.9% |
| `GetToken` | 40.6% |
| **Total** | **33.5%** |

Functions at 0% (`NewTokenManager`, `Authenticate`, `GetTokenForRequest`) require real system keychain or network — covered by integration tests in #77.

## Test plan
- [x] All 34 tests pass
- [x] Full test suite (`go test ./...`) green

Closes #76

🤖 Generated with [Claude Code](https://claude.com/claude-code)