### PR TITLE
Add context commands and state inspect commands

### DIFF
--- a/cmd/context.go
+++ b/cmd/context.go
@@ -1,0 +1,127 @@
+package cmd
+
+import (
+	"fmt"
+	"log"
+
+	"github.com/shapedthought/owlctl/config"
+	"github.com/shapedthought/owlctl/utils"
+	"github.com/spf13/cobra"
+)
+
+// contextCmd mirrors the kubectl context model — a familiar UX for switching
+// between named Veeam environments. These commands are aliases for the
+// equivalent `owlctl instance` operations.
+var contextCmd = &cobra.Command{
+	Use:   "context",
+	Short: "Switch and inspect the active environment context",
+	Long: `Manage the active context (named instance) for owlctl commands.
+
+Contexts map directly to named instances defined in owlctl.yaml. Use
+'context use' to switch environments — equivalent to 'instance set',
+but more natural for users familiar with kubectl.
+
+Examples:
+  owlctl context list               # list all defined contexts
+  owlctl context use vbr-prod       # switch active context
+  owlctl context current            # show the active context
+`,
+}
+
+var contextListCmd = &cobra.Command{
+	Use:   "list",
+	Short: "List all available contexts",
+	Long: `List all named instances defined in owlctl.yaml. The active context is marked with *.
+
+Examples:
+  owlctl context list
+`,
+	Run: func(cmd *cobra.Command, args []string) {
+		// Delegate to instance list — identical output
+		instanceListCmd.Run(cmd, args)
+	},
+}
+
+var contextUseCmd = &cobra.Command{
+	Use:   "use <name>",
+	Short: "Switch the active context",
+	Long: `Set a named instance as the active context. All subsequent commands will
+use this environment without needing --instance.
+
+The instance must be defined in owlctl.yaml. Use 'owlctl context use -'
+to clear the active context (equivalent to 'owlctl instance unset').
+
+Examples:
+  owlctl context use vbr-prod
+  owlctl context use azure-prod
+  owlctl context use -              # clear active context
+`,
+	Args: cobra.ExactArgs(1),
+	Run: func(cmd *cobra.Command, args []string) {
+		name := args[0]
+
+		// Special case: "-" clears the active context (kubectl convention)
+		if name == "-" {
+			settings, err := utils.TryReadSettings()
+			if err != nil {
+				log.Fatalf("Failed to read settings.json: %v", err)
+			}
+			if settings.DefaultInstance == "" {
+				fmt.Println("No active context is set.")
+				return
+			}
+			prev := settings.DefaultInstance
+			settings.DefaultInstance = ""
+			if err := utils.WriteSettings(settings); err != nil {
+				log.Fatalf("Failed to save settings: %v", err)
+			}
+			fmt.Printf("Switched away from context %q. No active context.\n", prev)
+			return
+		}
+
+		cfg, err := config.LoadConfig()
+		if err != nil {
+			log.Fatalf("Failed to load owlctl.yaml: %v", err)
+		}
+		if _, err := cfg.GetInstance(name); err != nil {
+			log.Fatalf("Cannot switch context: %v", err)
+		}
+
+		settings, err := utils.TryReadSettings()
+		if err != nil {
+			log.Fatalf("Failed to read settings.json: %v", err)
+		}
+		settings.DefaultInstance = name
+		if err := utils.WriteSettings(settings); err != nil {
+			log.Fatalf("Failed to save settings: %v", err)
+		}
+
+		fmt.Printf("Switched to context %q.\n", name)
+	},
+}
+
+var contextCurrentCmd = &cobra.Command{
+	Use:   "current",
+	Short: "Show the active context",
+	Long: `Print the name of the currently active context.
+
+Examples:
+  owlctl context current
+`,
+	Args: cobra.NoArgs,
+	Run: func(cmd *cobra.Command, args []string) {
+		settings, _ := utils.TryReadSettings()
+		if settings.DefaultInstance == "" {
+			fmt.Println("(none)")
+		} else {
+			fmt.Println(settings.DefaultInstance)
+		}
+	},
+}
+
+func init() {
+	contextCmd.AddCommand(contextListCmd)
+	contextCmd.AddCommand(contextUseCmd)
+	contextCmd.AddCommand(contextCurrentCmd)
+	rootCmd.AddCommand(contextCmd)
+}

--- a/cmd/context.go
+++ b/cmd/context.go
@@ -15,6 +15,14 @@ import (
 var contextCmd = &cobra.Command{
 	Use:   "context",
 	Short: "Switch and inspect the active environment context",
+	// PersistentPreRunE is set to a no-op so that all context subcommands bypass
+	// the root PersistentPreRunE, which tries to activate DefaultInstance. This is
+	// important because:
+	//   - context use/current/list only manage config files and do not need a live
+	//     server connection
+	//   - context use - is the recovery command for a stale DefaultInstance; if the
+	//     root hook runs first it would error before the clear can happen
+	PersistentPreRunE: func(cmd *cobra.Command, args []string) error { return nil },
 	Long: `Manage the active context (named instance) for owlctl commands.
 
 Contexts map directly to named instances defined in owlctl.yaml. Use

--- a/cmd/state.go
+++ b/cmd/state.go
@@ -1,8 +1,12 @@
 package cmd
 
 import (
+	"encoding/json"
 	"fmt"
 	"log"
+	"sort"
+	"text/tabwriter"
+	"os"
 
 	"github.com/shapedthought/owlctl/state"
 	"github.com/spf13/cobra"
@@ -17,8 +21,62 @@ State is stored locally and tracks which resources have been applied or snapshot
 `,
 }
 
+var stateListCmd = &cobra.Command{
+	Use:   "list",
+	Short: "List all tracked resources in state",
+	Long: `Display a summary table of every resource currently tracked in state.
+
+Shows all instances. Use --instance to filter to a specific instance.
+
+Examples:
+  # List all tracked resources
+  owlctl state list
+
+  # List resources for a specific instance
+  owlctl state list --instance vbr-prod
+`,
+	Run: func(cmd *cobra.Command, args []string) {
+		listStateResources()
+	},
+}
+
+var stateShowCmd = &cobra.Command{
+	Use:   "show <resource-name>",
+	Short: "Show full detail for a tracked resource",
+	Long: `Display detailed information for a single resource in state, including
+metadata and the full spec that was last applied or snapshotted.
+
+Examples:
+  # Show detail for a repository
+  owlctl state show "Default Backup Repository"
+
+  # Show detail for a job
+  owlctl state show "Production Database Backup"
+`,
+	Args: cobra.ExactArgs(1),
+	Run: func(cmd *cobra.Command, args []string) {
+		showStateResource(args[0])
+	},
+}
+
+var statePathCmd = &cobra.Command{
+	Use:   "path",
+	Short: "Print the state file path",
+	Long: `Print the path to the state.json file owlctl is using.
+
+Useful for debugging, CI environments, or scripting.
+
+Examples:
+  owlctl state path
+`,
+	Run: func(cmd *cobra.Command, args []string) {
+		stateMgr := state.NewManager()
+		fmt.Println(stateMgr.GetStatePath())
+	},
+}
+
 var stateHistoryCmd = &cobra.Command{
-	Use:   "history [resource-name]",
+	Use:   "history <resource-name>",
 	Short: "Show audit history for a resource",
 	Long: `Display the audit trail of actions taken on a resource.
 
@@ -39,6 +97,153 @@ Examples:
 	Run: func(cmd *cobra.Command, args []string) {
 		showResourceHistory(args[0])
 	},
+}
+
+func listStateResources() {
+	stateMgr := state.NewManager()
+
+	if !stateMgr.StateExists() {
+		fmt.Println("No state file found. Run a snapshot or apply command to initialise state.")
+		fmt.Printf("Expected location: %s\n", stateMgr.GetStatePath())
+		return
+	}
+
+	st, err := stateMgr.Load()
+	if err != nil {
+		log.Fatalf("Failed to load state: %v", err)
+	}
+
+	if len(st.Instances) == 0 {
+		fmt.Println("State file exists but contains no tracked resources.")
+		return
+	}
+
+	// Collect all instance names sorted
+	instanceNames := make([]string, 0, len(st.Instances))
+	for name := range st.Instances {
+		instanceNames = append(instanceNames, name)
+	}
+	sort.Strings(instanceNames)
+
+	// Filter by --instance flag if set
+	filterInstance := instanceFlag
+	if filterInstance != "" {
+		filtered := instanceNames[:0]
+		for _, n := range instanceNames {
+			if n == filterInstance {
+				filtered = append(filtered, n)
+			}
+		}
+		if len(filtered) == 0 {
+			fmt.Printf("No resources found for instance '%s'.\n", filterInstance)
+			return
+		}
+		instanceNames = filtered
+	}
+
+	w := tabwriter.NewWriter(os.Stdout, 0, 0, 2, ' ', 0)
+	fmt.Fprintln(w, "INSTANCE\tNAME\tTYPE\tORIGIN\tLAST APPLIED")
+
+	total := 0
+	for _, instName := range instanceNames {
+		inst := st.Instances[instName]
+		if inst == nil || len(inst.Resources) == 0 {
+			continue
+		}
+
+		// Sort resource names for stable output
+		resourceNames := make([]string, 0, len(inst.Resources))
+		for name := range inst.Resources {
+			resourceNames = append(resourceNames, name)
+		}
+		sort.Strings(resourceNames)
+
+		for _, resName := range resourceNames {
+			r := inst.Resources[resName]
+			lastApplied := r.LastApplied.Format("2006-01-02 15:04")
+			if r.LastApplied.IsZero() {
+				lastApplied = "-"
+			}
+			fmt.Fprintf(w, "%s\t%s\t%s\t%s\t%s\n",
+				instName, r.Name, r.Type, r.Origin, lastApplied)
+			total++
+		}
+	}
+	w.Flush()
+
+	fmt.Printf("\n%d resource(s) tracked", total)
+	if filterInstance != "" {
+		fmt.Printf(" in instance '%s'", filterInstance)
+	}
+	fmt.Printf(" (state v%d: %s)\n", st.Version, stateMgr.GetStatePath())
+}
+
+func showStateResource(resourceName string) {
+	stateMgr := state.NewManager()
+
+	if !stateMgr.StateExists() {
+		fmt.Println("No state file found. Run a snapshot or apply command to initialise state.")
+		fmt.Printf("Expected location: %s\n", stateMgr.GetStatePath())
+		return
+	}
+
+	// Load state directly to search all instances
+	st, err := stateMgr.Load()
+	if err != nil {
+		log.Fatalf("Failed to load state: %v", err)
+	}
+
+	// Find the resource across all instances (prefer active instance if duplicated)
+	var found *state.Resource
+	var foundInstance string
+
+	activeInst := instanceFlag
+	if activeInst == "" {
+		activeInst = "default"
+	}
+
+	// First pass: look in active instance
+	if inst, ok := st.Instances[activeInst]; ok && inst != nil {
+		if r, ok := inst.Resources[resourceName]; ok {
+			found = r
+			foundInstance = activeInst
+		}
+	}
+
+	// Second pass: search all instances if not found in active
+	if found == nil {
+		for instName, inst := range st.Instances {
+			if inst == nil {
+				continue
+			}
+			if r, ok := inst.Resources[resourceName]; ok {
+				found = r
+				foundInstance = instName
+				break
+			}
+		}
+	}
+
+	if found == nil {
+		log.Fatalf("Resource '%s' not found in state.", resourceName)
+	}
+
+	fmt.Printf("Resource: %s\n", found.Name)
+	fmt.Printf("Instance: %s\n", foundInstance)
+	fmt.Printf("Type:     %s\n", found.Type)
+	fmt.Printf("ID:       %s\n", found.ID)
+	fmt.Printf("Origin:   %s\n", found.Origin)
+	if !found.LastApplied.IsZero() {
+		fmt.Printf("Last Applied: %s by %s\n", found.LastApplied.Format("2006-01-02 15:04:05"), found.LastAppliedBy)
+	}
+	fmt.Printf("Spec Fields: %d\n", len(found.Spec))
+
+	fmt.Println("\nSpec:")
+	specJSON, err := json.MarshalIndent(found.Spec, "  ", "  ")
+	if err != nil {
+		log.Fatalf("Failed to marshal spec: %v", err)
+	}
+	fmt.Printf("  %s\n", string(specJSON))
 }
 
 func showResourceHistory(resourceName string) {
@@ -63,14 +268,12 @@ func showResourceHistory(resourceName string) {
 		timestamp := event.Timestamp.Format("2006-01-02 15:04:05")
 
 		if len(event.Fields) > 0 {
-			// Show field count for apply events
 			fieldInfo := fmt.Sprintf("%d field(s)", len(event.Fields))
 			if event.Partial {
 				fieldInfo += " [partial]"
 			}
 			fmt.Printf("  %s - %s by %s (%s)\n", timestamp, event.Action, event.User, fieldInfo)
 
-			// Show first few fields
 			maxFields := 3
 			for i, field := range event.Fields {
 				if i >= maxFields {
@@ -88,6 +291,9 @@ func showResourceHistory(resourceName string) {
 }
 
 func init() {
+	stateCmd.AddCommand(stateListCmd)
+	stateCmd.AddCommand(stateShowCmd)
+	stateCmd.AddCommand(statePathCmd)
 	stateCmd.AddCommand(stateHistoryCmd)
 	rootCmd.AddCommand(stateCmd)
 }

--- a/cmd/state.go
+++ b/cmd/state.go
@@ -4,9 +4,9 @@ import (
 	"encoding/json"
 	"fmt"
 	"log"
+	"os"
 	"sort"
 	"text/tabwriter"
-	"os"
 
 	"github.com/shapedthought/owlctl/state"
 	"github.com/spf13/cobra"
@@ -199,7 +199,11 @@ func showStateResource(resourceName string) {
 
 	activeInst := instanceFlag
 	if activeInst == "" {
-		activeInst = "default"
+		if envInst := os.Getenv("OWLCTL_ACTIVE_INSTANCE"); envInst != "" {
+			activeInst = envInst
+		} else {
+			activeInst = "default"
+		}
 	}
 
 	// First pass: look in active instance

--- a/docs/command-reference.md
+++ b/docs/command-reference.md
@@ -8,6 +8,7 @@ Fast reference for common owlctl commands. See full documentation in [User Guide
 - [Imperative Commands (All Products)](#imperative-commands-all-products)
 - [Declarative Commands (VBR Only)](#declarative-commands-vbr-only)
 - [Group Commands](#group-commands)
+- [Context Commands](#context-commands)
 - [Instance Commands](#instance-commands)
 - [Target Commands](#target-commands)
 - [Common Flags](#common-flags)
@@ -276,6 +277,31 @@ owlctl job diff --group sql-tier
 ```
 
 **Note:** `--group` is mutually exclusive with positional file args, `-o/--overlay`, `--env`, and `--all`.
+
+---
+
+## Context Commands
+
+Context commands provide a familiar way to switch between environments, modelled on `kubectl config`. A context is a named instance from `owlctl.yaml`.
+
+```bash
+# List all contexts (* marks the active one)
+owlctl context list
+
+# Switch active context
+owlctl context use vbr-prod
+owlctl context use azure-prod
+
+# Clear the active context
+owlctl context use -
+
+# Show the current active context
+owlctl context current
+```
+
+> **Context vs Instance:** `context` commands are aliases for the equivalent `instance` operations — `context use` = `instance set`, `context current` = `instance get`, `context list` = `instance list`. Use whichever feels natural. All instance configuration (add, remove, show) remains under `owlctl instance`.
+
+> **Familiar with kubectl?** The pattern is the same: `owlctl context use` = `kubectl config use-context`, `owlctl context list` = `kubectl config get-contexts`, `owlctl context current` = `kubectl config current-context`.
 
 ---
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -177,6 +177,20 @@ export OWLCTL_PROD_PASSWORD="your-password"
   --credential-ref PROD
 ```
 
+**Managing multiple environments (e.g. VBR + Azure)?** Use `context` commands to switch between them:
+
+```bash
+./owlctl instance add azure-prod --url azure.example.com --product azure --credential-ref AZURE
+
+# Switch context when working on a different environment
+./owlctl context use azure-prod
+./owlctl get policies
+
+# Switch back
+./owlctl context use vbr-prod
+./owlctl context list    # see all environments, * marks the active one
+```
+
 > Skip this step if you're only using imperative mode with environment variables.
 
 ### 5. Login


### PR DESCRIPTION
## Summary

- **`owlctl context use/list/current`** — kubectl-style aliases for `instance set/get/list`, making environment switching familiar for users coming from Kubernetes. `context use -` clears the active context.
- **`owlctl state list`** — table of all tracked resources across all instances, with optional `--instance` filter
- **`owlctl state show <name>`** — full spec detail for a single tracked resource
- **`owlctl state path`** — prints the state file path (useful for CI debugging and scripting)
- **docs**: Context Commands section added to `command-reference.md` with kubectl comparison callout
- **docs**: Multi-environment context switching example added to `getting-started.md`

## Motivation

Previously there was no way to inspect state without opening `~/.owlctl/state.json` directly, and switching between environments required `owlctl instance set` which isn't intuitive for kubectl users. This PR addresses both gaps.

## Test plan

- [ ] `go test ./...` passes
- [ ] `owlctl context list` shows instances from owlctl.yaml
- [ ] `owlctl context use <name>` updates default instance in settings.json
- [ ] `owlctl context use -` clears the active context
- [ ] `owlctl context current` prints the active context name
- [ ] `owlctl state list` shows resources grouped by instance
- [ ] `owlctl state show <name>` shows spec and metadata for a resource
- [ ] `owlctl state path` prints the correct state file path
- [ ] `owlctl --instance <name> state list` filters to that instance

🤖 Generated with [Claude Code](https://claude.com/claude-code)