### PR TITLE
Docs correctness sweep + reconcile phantom `adopt` command

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -101,6 +101,21 @@ owlctl supports declarative, infrastructure-as-code management for VBR resources
 | Scale-Out Repos | `repo sobr-export` | `repo sobr-apply` | `repo sobr-snapshot` | `repo sobr-diff` |
 | Encryption Passwords | `encryption export` | N/A (read-only) | `encryption snapshot` | `encryption diff` |
 | KMS Servers | `encryption kms-export` | `encryption kms-apply` | `encryption kms-snapshot` | `encryption kms-diff` |
+| Config Backup (singleton) | `config-backup export` | `config-backup apply` | `config-backup snapshot` | `config-backup diff` |
+
+**Global commands (operate across all resource types at once):**
+- `owlctl export --all [-d <dir>] [--all-instances] [--from-state]` - Export every resource type to a product/instance/type directory tree. `--from-state` generates YAML offline from `state.json` without contacting VBR.
+- `owlctl snapshot --all [--all-instances]` - Snapshot every resource type (except jobs, which are declarative-managed) into `state.json` in one operation.
+
+**State inspection commands:**
+- `owlctl state list [--instance <name>]` - Table of all tracked resources (Instance, Name, Type, Origin, LastApplied)
+- `owlctl state show <name>` - Full detail + spec for one resource
+- `owlctl state history <name>` - Audit trail of actions (snapshotted/created/applied) with changed fields
+- `owlctl state path` - Print the `state.json` path
+
+**Context commands (kubectl-style aliases over `instance`):**
+- `owlctl context list` / `current` - List instances / show active context
+- `owlctl context use <name>` - Set active context; `owlctl context use -` clears it
 
 #### Commands
 
@@ -159,7 +174,7 @@ All diff commands support:
           "name": "Resource Name",
           "lastApplied": "2026-02-01T14:30:00Z",
           "lastAppliedBy": "username",
-          "origin": "applied|snapshot",
+          "origin": "applied|observed",
           "spec": { }
         }
       }
@@ -177,7 +192,8 @@ Resources are scoped under `instances["<instance-name>"]`. When no `--instance` 
 
 **State Operations:**
 - State is automatically updated on successful `apply` (origin: "applied")
-- State is explicitly updated on `snapshot` commands (origin: "snapshot")
+- State is explicitly updated on `snapshot` commands (origin: "observed")
+- Each resource also carries a `history` audit trail (added in v3); inspect with `owlctl state history <name>`
 - Drift detection compares state spec vs live VBR configuration
 - State is NOT for audit compliance (use Git history + CI/CD logs + VBR audit logs)
 
@@ -330,8 +346,13 @@ groups:
 - `cmd/encryption.go` - Encryption password and KMS server management
 - `cmd/severity_config.go` - Custom severity configuration
 - `cmd/instance.go` - Instance add/remove/set/get/unset/list/show commands
+- `cmd/context.go` - kubectl-style `context list/use/current` (aliases over instance state)
 - `cmd/group_resource.go` - Group apply/diff with instance activation + specsDir helpers
 - `cmd/group.go` - Group list/show commands
+- `cmd/global_export.go` / `cmd/global_snapshot.go` - `export --all` / `snapshot --all` across all resource types
+- `cmd/state.go` - `state list/show/history/path` inspection commands
+- `cmd/configbackup.go` - VBR config-backup singleton resource (snapshot/diff/export/apply)
+- `cmd/export_registry.go` / `cmd/vbr_exports.go` - Resource-type registry driving global export/snapshot
 
 **Configuration:**
 - `config/owlctl_config.go` - VCLIConfig, InstanceConfig, GroupConfig, config loading

--- a/cmd/apply_reporting.go
+++ b/cmd/apply_reporting.go
@@ -250,13 +250,13 @@ func printSpecSummary(spec map[string]interface{}, indent string) {
 }
 
 // printNotFoundGuidance prints guidance when a resource is not found
-func printNotFoundGuidance(resourceType, resourceName, adoptCmd string) {
+func printNotFoundGuidance(resourceType, resourceName, applyCmd string) {
 	fmt.Fprintf(
 		os.Stderr,
 		"\nError: %s \"%s\" no longer exists in VBR.\n"+
-			"Cannot apply — resource must be recreated manually, then adopted:\n"+
+			"Cannot apply — recreate it manually in the VBR console, then re-apply:\n"+
 			"  %s\n",
-		resourceType, resourceName, adoptCmd,
+		resourceType, resourceName, applyCmd,
 	)
 }
 
@@ -267,7 +267,7 @@ type RemediationGuidance struct {
 	ResourceName string
 	ApplyCmd     string // Command to remediate (for applied resources)
 	ExportCmd    string // Command to export (for observed resources)
-	AdoptCmd     string // Command to adopt (for observed resources)
+	ManageCmd    string // Command to bring an observed resource under management ("" for read-only resources)
 }
 
 // printRemediationGuidance prints appropriate guidance based on resource origin
@@ -283,9 +283,14 @@ func printRemediationGuidance(g RemediationGuidance) {
 			fmt.Printf("  %s\n", g.ApplyCmd)
 		}
 	case "observed":
-		fmt.Printf("\nThis resource is monitored only. To enable remediation:\n")
-		fmt.Printf("  1. Export: %s\n", g.ExportCmd)
-		fmt.Printf("  2. Adopt:  %s\n", g.AdoptCmd)
+		if g.ManageCmd == "" {
+			// Read-only resource (e.g. encryption passwords) — cannot be applied.
+			fmt.Printf("\nThis resource is read-only and monitored only. Remediate manually in the VBR console.\n")
+		} else {
+			fmt.Printf("\nThis resource is monitored only (origin: observed). To bring it under declarative management:\n")
+			fmt.Printf("  1. Export: %s\n", g.ExportCmd)
+			fmt.Printf("  2. Apply:  %s\n", g.ManageCmd)
+		}
 	default:
 		// Legacy resource without origin - show snapshot command
 		fmt.Printf("\nThe %s has drifted from the snapshot configuration.\n", g.ResourceType)
@@ -320,7 +325,7 @@ func BuildRepoGuidance(resourceName, origin string) RemediationGuidance {
 		ResourceName: resourceName,
 		ApplyCmd:     fmt.Sprintf("owlctl repo apply repos/%s.yaml", sanitizeFileName(resourceName)),
 		ExportCmd:    fmt.Sprintf("owlctl repo export \"%s\" -o repos/%s.yaml", resourceName, sanitizeFileName(resourceName)),
-		AdoptCmd:     fmt.Sprintf("owlctl repo adopt repos/%s.yaml", sanitizeFileName(resourceName)),
+		ManageCmd:    fmt.Sprintf("owlctl repo apply repos/%s.yaml", sanitizeFileName(resourceName)),
 	}
 }
 
@@ -332,7 +337,7 @@ func BuildSobrGuidance(resourceName, origin string) RemediationGuidance {
 		ResourceName: resourceName,
 		ApplyCmd:     fmt.Sprintf("owlctl repo sobr-apply sobrs/%s.yaml", sanitizeFileName(resourceName)),
 		ExportCmd:    fmt.Sprintf("owlctl repo sobr-export \"%s\" -o sobrs/%s.yaml", resourceName, sanitizeFileName(resourceName)),
-		AdoptCmd:     fmt.Sprintf("owlctl repo sobr-adopt sobrs/%s.yaml", sanitizeFileName(resourceName)),
+		ManageCmd:    fmt.Sprintf("owlctl repo sobr-apply sobrs/%s.yaml", sanitizeFileName(resourceName)),
 	}
 }
 
@@ -344,7 +349,7 @@ func BuildJobGuidance(resourceName, origin string) RemediationGuidance {
 		ResourceName: resourceName,
 		ApplyCmd:     fmt.Sprintf("owlctl job apply jobs/%s.yaml", sanitizeFileName(resourceName)),
 		ExportCmd:    fmt.Sprintf("owlctl export \"%s\" -o jobs/%s.yaml", resourceName, sanitizeFileName(resourceName)),
-		AdoptCmd:     fmt.Sprintf("owlctl job adopt jobs/%s.yaml", sanitizeFileName(resourceName)),
+		ManageCmd:    fmt.Sprintf("owlctl job apply jobs/%s.yaml", sanitizeFileName(resourceName)),
 	}
 }
 
@@ -354,10 +359,10 @@ func BuildEncryptionGuidance(resourceName, origin string) RemediationGuidance {
 		Origin:       origin,
 		ResourceType: "encryption password",
 		ResourceName: resourceName,
-		// Encryption passwords are read-only in VBR API - empty ApplyCmd triggers read-only message
+		// Encryption passwords are read-only in VBR API - empty ApplyCmd/ManageCmd triggers read-only message
 		ApplyCmd:  "",
 		ExportCmd: fmt.Sprintf("owlctl encryption export \"%s\" -o encryption/%s.yaml", resourceName, sanitizeFileName(resourceName)),
-		AdoptCmd:  fmt.Sprintf("owlctl encryption adopt encryption/%s.yaml", sanitizeFileName(resourceName)),
+		ManageCmd: "",
 	}
 }
 
@@ -369,7 +374,7 @@ func BuildKmsGuidance(resourceName, origin string) RemediationGuidance {
 		ResourceName: resourceName,
 		ApplyCmd:     fmt.Sprintf("owlctl encryption kms-apply kms/%s.yaml", sanitizeFileName(resourceName)),
 		ExportCmd:    fmt.Sprintf("owlctl encryption kms-export \"%s\" -o kms/%s.yaml", resourceName, sanitizeFileName(resourceName)),
-		AdoptCmd:     fmt.Sprintf("owlctl encryption kms-adopt kms/%s.yaml", sanitizeFileName(resourceName)),
+		ManageCmd:    fmt.Sprintf("owlctl encryption kms-apply kms/%s.yaml", sanitizeFileName(resourceName)),
 	}
 }
 

--- a/cmd/apply_reporting.go
+++ b/cmd/apply_reporting.go
@@ -341,14 +341,15 @@ func BuildSobrGuidance(resourceName, origin string) RemediationGuidance {
 	}
 }
 
-// BuildJobGuidance creates guidance for job diff
-func BuildJobGuidance(resourceName, origin string) RemediationGuidance {
+// BuildJobGuidance creates guidance for job diff. Job export is keyed by ID
+// (the `owlctl job export` subcommand takes a job ID, not a name).
+func BuildJobGuidance(resourceName, resourceID, origin string) RemediationGuidance {
 	return RemediationGuidance{
 		Origin:       origin,
 		ResourceType: "job",
 		ResourceName: resourceName,
 		ApplyCmd:     fmt.Sprintf("owlctl job apply jobs/%s.yaml", sanitizeFileName(resourceName)),
-		ExportCmd:    fmt.Sprintf("owlctl export \"%s\" -o jobs/%s.yaml", resourceName, sanitizeFileName(resourceName)),
+		ExportCmd:    fmt.Sprintf("owlctl job export %s -o jobs/%s.yaml", resourceID, sanitizeFileName(resourceName)),
 		ManageCmd:    fmt.Sprintf("owlctl job apply jobs/%s.yaml", sanitizeFileName(resourceName)),
 	}
 }

--- a/cmd/encryption.go
+++ b/cmd/encryption.go
@@ -426,7 +426,7 @@ func diffAllEncryptionPasswords() {
 		fmt.Printf("  - %d passwords drifted — manual remediation required in VBR console\n", driftedApplied)
 	}
 	if driftedObserved > 0 {
-		fmt.Printf("  - %d passwords drifted (observed) — adopt to enable tracking\n", driftedObserved)
+		fmt.Printf("  - %d passwords drifted (observed) — read-only; remediate manually in the VBR console\n", driftedObserved)
 	}
 	// Also count inventory changes (added/removed) which were counted earlier
 	inventoryChanges := driftedCount - driftedApplied - driftedObserved
@@ -878,7 +878,7 @@ func diffAllKmsServers() {
 		fmt.Printf("  - %d KMS servers drifted — remediate with: owlctl encryption kms-apply <spec>.yaml\n", driftedApplied)
 	}
 	if driftedObserved > 0 {
-		fmt.Printf("  - %d KMS servers drifted (observed) — adopt to enable remediation\n", driftedObserved)
+		fmt.Printf("  - %d KMS servers drifted (observed, monitor-only) — export then apply a spec to enable remediation\n", driftedObserved)
 	}
 	// Also count inventory changes (added/removed) which were counted earlier
 	inventoryChanges := driftedCount - driftedApplied - driftedObserved

--- a/cmd/jobs.go
+++ b/cmd/jobs.go
@@ -539,7 +539,7 @@ func diffAllJobs() {
 		fmt.Printf("  - %d jobs drifted — remediate with: owlctl job apply <spec>.yaml\n", driftedApplied)
 	}
 	if driftedObserved > 0 {
-		fmt.Printf("  - %d jobs drifted (observed) — adopt to enable remediation\n", driftedObserved)
+		fmt.Printf("  - %d jobs drifted (observed, monitor-only) — export then apply a spec to enable remediation\n", driftedObserved)
 	}
 
 	if totalDrifted > 0 {

--- a/cmd/jobs.go
+++ b/cmd/jobs.go
@@ -455,7 +455,7 @@ func diffSingleJob(jobName string) {
 	}
 
 	// Show guidance based on origin
-	printRemediationGuidance(BuildJobGuidance(jobName, resource.Origin))
+	printRemediationGuidance(BuildJobGuidance(jobName, resource.ID, resource.Origin))
 
 	os.Exit(exitCodeForDrifts(drifts))
 }

--- a/cmd/repo.go
+++ b/cmd/repo.go
@@ -362,7 +362,7 @@ func diffAllRepos() {
 		fmt.Printf("  - %d repositories drifted — remediate with: owlctl repo apply <spec>.yaml\n", driftedApplied)
 	}
 	if driftedObserved > 0 {
-		fmt.Printf("  - %d repositories drifted (observed) — adopt to enable remediation\n", driftedObserved)
+		fmt.Printf("  - %d repositories drifted (observed, monitor-only) — export then apply a spec to enable remediation\n", driftedObserved)
 	}
 
 	totalDrifted := driftedApplied + driftedObserved
@@ -812,7 +812,7 @@ func diffAllSobrs() {
 		fmt.Printf("  - %d scale-out repositories drifted — remediate with: owlctl repo sobr-apply <spec>.yaml\n", driftedApplied)
 	}
 	if driftedObserved > 0 {
-		fmt.Printf("  - %d scale-out repositories drifted (observed) — adopt to enable remediation\n", driftedObserved)
+		fmt.Printf("  - %d scale-out repositories drifted (observed, monitor-only) — export then apply a spec to enable remediation\n", driftedObserved)
 	}
 
 	totalDrifted := driftedApplied + driftedObserved

--- a/docs/authentication.md
+++ b/docs/authentication.md
@@ -496,7 +496,7 @@ echo $OWLCTL_URL
 Edit `settings.json`:
 ```json
 {
-  "skipTLSVerify": true
+  "apiNotSecure": true
 }
 ```
 

--- a/docs/command-reference.md
+++ b/docs/command-reference.md
@@ -7,6 +7,7 @@ Fast reference for common owlctl commands. See full documentation in [User Guide
 - [Setup & Authentication](#setup--authentication)
 - [Imperative Commands (All Products)](#imperative-commands-all-products)
 - [Declarative Commands (VBR Only)](#declarative-commands-vbr-only)
+- [State Commands](#state-commands)
 - [Group Commands](#group-commands)
 - [Context Commands](#context-commands)
 - [Instance Commands](#instance-commands)
@@ -277,6 +278,29 @@ owlctl job plan base.yaml
 owlctl job plan base.yaml --overlay prod.yaml
 owlctl job plan base.yaml --overlay prod.yaml --show-yaml
 ```
+
+---
+
+## State Commands
+
+Inspect the tracked resources recorded in `state.json` (resources are scoped per instance — see [State Management](state-management.md)).
+
+```bash
+# List all tracked resources (Instance, Name, Type, Origin, LastApplied)
+owlctl state list
+owlctl state list --instance vbr-prod      # filter to one instance
+
+# Show full detail and spec for one resource
+owlctl state show "Database Backup"
+
+# Show the audit trail (snapshotted / created / applied) for a resource
+owlctl state history "Database Backup"
+
+# Print the resolved state.json path
+owlctl state path
+```
+
+`origin` is `applied` (written by `apply`) or `observed` (written by `snapshot`).
 
 ---
 

--- a/docs/declarative-mode.md
+++ b/docs/declarative-mode.md
@@ -121,7 +121,7 @@ Maps are merged recursively, arrays are replaced, and labels are combined across
 owlctl maintains state in `state.json` to track:
 - Last known configuration of each resource
 - When snapshots were taken
-- Configuration origin (applied vs adopted)
+- Configuration origin (applied vs observed)
 
 ### 8. Drift Detection
 Compare live VBR configuration against desired state to detect unauthorized changes with security-aware severity classification.
@@ -368,7 +368,7 @@ owlctl config-backup snapshot
           "name": "Default Backup Repository",
           "lastApplied": "2024-01-15T10:31:00Z",
           "lastAppliedBy": "administrator",
-          "origin": "snapshot",
+          "origin": "observed",
           "spec": { }
         }
       }

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -466,10 +466,10 @@ See [Declarative Mode Guide](declarative-mode.md#groups) for the full groups ref
 
 **Option 1: Skip verification (NOT recommended for production)**
 
-Set in `settings.json`:
+Pass `--insecure` on any command, or set in `settings.json`:
 ```json
 {
-  "skipTLSVerify": true
+  "apiNotSecure": true
 }
 ```
 

--- a/docs/gitops-workflows.md
+++ b/docs/gitops-workflows.md
@@ -666,7 +666,14 @@ variables:
 .owlctl-setup: &owlctl-setup
   before_script:
     - apt-get update && apt-get install -y curl
-    - curl -sL https://github.com/shapedthought/owlctl/releases/${OWLCTL_VERSION}/download/owlctl-linux-amd64.tar.gz -o owlctl.tar.gz
+    # 'latest' and pinned tags use different GitHub release URL forms
+    - |
+      if [ "$OWLCTL_VERSION" = "latest" ]; then
+        DL="https://github.com/shapedthought/owlctl/releases/latest/download/owlctl-linux-amd64.tar.gz"
+      else
+        DL="https://github.com/shapedthought/owlctl/releases/download/${OWLCTL_VERSION}/owlctl-linux-amd64.tar.gz"
+      fi
+    - curl -sL "$DL" -o owlctl.tar.gz
     - tar xzf owlctl.tar.gz
     - chmod +x owlctl
     - ./owlctl profile --set vbr

--- a/docs/gitops-workflows.md
+++ b/docs/gitops-workflows.md
@@ -204,15 +204,15 @@ Thumbs.db
 
 ```json
 {
-  "skipTLSVerify": false
+  "apiNotSecure": false
 }
 ```
 
 **Commit this** - Controls owlctl behavior, contains no secrets.
 
 **Environment-specific settings:**
-- Production: `"skipTLSVerify": false` (require valid certificates)
-- Development: `"skipTLSVerify": true` (allow self-signed certs)
+- Production: `"apiNotSecure": false` (require valid certificates)
+- Development: `"apiNotSecure": true` (allow self-signed certs)
 
 ### Credentials Management
 
@@ -660,13 +660,13 @@ stages:
   - verify
 
 variables:
-  VCLI_VERSION: "latest"
+  OWLCTL_VERSION: "latest"
   OWLCTL_SETTINGS_PATH: "./.owlctl/"
 
 .owlctl-setup: &owlctl-setup
   before_script:
     - apt-get update && apt-get install -y curl
-    - curl -sL https://github.com/shapedthought/owlctl/releases/${VCLI_VERSION}/download/owlctl-linux-amd64.tar.gz -o owlctl.tar.gz
+    - curl -sL https://github.com/shapedthought/owlctl/releases/${OWLCTL_VERSION}/download/owlctl-linux-amd64.tar.gz -o owlctl.tar.gz
     - tar xzf owlctl.tar.gz
     - chmod +x owlctl
     - ./owlctl profile --set vbr
@@ -939,7 +939,7 @@ spec:
   credentials:
     tenantId: "${AZURE_TENANT_ID}"
     clientId: "${AZURE_CLIENT_ID}"
-    # clientSecret: provided via VCLI_KMS_SECRET env var
+    # clientSecret: provided via OWLCTL_KMS_SECRET env var
 ```
 
 ### 7. Drift Detection as Security Control

--- a/docs/state-management.md
+++ b/docs/state-management.md
@@ -25,7 +25,7 @@ owlctl maintains state in `state.json` to enable drift detection and track decla
 State management enables:
 - **Drift detection** - Compare live VBR configuration against desired state
 - **Change tracking** - Know when configurations were last captured
-- **Origin tracking** - Distinguish between applied, adopted, and exported resources
+- **Origin tracking** - Distinguish between applied and observed resources
 - **GitOps workflows** - Version control your infrastructure state
 
 ## What is State?
@@ -33,9 +33,8 @@ State management enables:
 State is owlctl's record of the last known configuration for each managed resource. When you snapshot or apply a resource, owlctl saves its configuration to `state.json`. Later, the diff command compares the current VBR configuration against this saved state to detect drift.
 
 **Key concepts:**
-- **Snapshot** - Captures current VBR configuration and saves to state
-- **Apply** - Updates VBR and automatically snapshots the new configuration
-- **Adopt** - Takes a snapshot without making changes (for existing resources)
+- **Snapshot** - Captures current VBR configuration and saves to state (origin: `observed`)
+- **Apply** - Updates VBR and automatically snapshots the new configuration (origin: `applied`)
 - **Drift** - Differences between state and current VBR configuration
 
 ## State File Location
@@ -223,29 +222,23 @@ owlctl encryption kms-snapshot "Azure Key Vault"
 owlctl encryption kms-snapshot --all
 ```
 
-### Adopt Commands
+### Bringing Existing Resources Under Management
 
-Adopt takes a snapshot of an existing resource to bring it under declarative management without making any changes. This is useful when you want to start managing existing resources declaratively.
+To start tracking a resource that already exists in VBR, capture it into state, then choose how to manage it:
+
+- **Monitor only** — `snapshot` records the current configuration with `origin: observed`. Drift is detected, but owlctl never modifies the resource.
+- **Manage declaratively** — `export` the resource to YAML, commit it, then `apply` it. Apply writes `origin: applied`, enabling remediation by re-applying the spec.
 
 ```bash
-# Adopt repository
-owlctl repo adopt "Default Backup Repository"
-owlctl repo adopt --all
+# Monitor an existing repository (observe only)
+owlctl repo snapshot "Default Backup Repository"
 
-# Adopt SOBR
-owlctl repo sobr-adopt "SOBR-Production"
-owlctl repo sobr-adopt --all
-
-# Adopt KMS server
-owlctl encryption kms-adopt "Azure Key Vault"
-owlctl encryption kms-adopt --all
+# ...or bring it under declarative management
+owlctl repo export "Default Backup Repository" -o repos/default.yaml
+owlctl repo apply repos/default.yaml
 ```
 
-**Adopt vs Snapshot:**
-- Both capture current configuration and save to state
-- Adopt marks `origin: "adopted"` in state
-- Snapshot marks `origin: "snapshot"` in state
-- Functionally identical, but origin tracking helps understand how resources were added
+> **Encryption passwords** are read-only in the VBR API — they can only be snapshotted (`observed`), never applied.
 
 ### Apply Commands
 
@@ -265,7 +258,7 @@ owlctl repo sobr-apply sobr.yaml
 owlctl encryption kms-apply kms.yaml
 ```
 
-**Note:** Jobs are only snapshotted via apply. There is no manual job snapshot command.
+**Note:** Apply snapshots automatically on success. Jobs can also be snapshotted directly with `owlctl job snapshot` (jobs are excluded from the global `snapshot --all`).
 
 ## State Origins
 
@@ -273,20 +266,17 @@ The `origin` field in state tracks how a resource entered declarative management
 
 | Origin | Meaning | How Created |
 |--------|---------|-------------|
-| `applied` | Configuration was applied via YAML | `owlctl job apply`, `owlctl repo apply`, etc. |
-| `adopted` | Existing resource adopted into management | `owlctl repo adopt`, `owlctl repo sobr-adopt`, etc. |
-| `snapshot` | Manual snapshot taken | `owlctl repo snapshot`, `owlctl encryption snapshot`, etc. |
-| `exported` | Exported to YAML but not yet applied | `owlctl export`, `owlctl repo export`, etc. |
+| `applied` | Configuration was applied from YAML | `owlctl job apply`, `owlctl repo apply`, etc. |
+| `observed` | Captured by a snapshot (monitor-only) | `owlctl repo snapshot`, `owlctl encryption snapshot`, etc. |
 
-**Origin is informational only** - it doesn't affect drift detection or other operations. It helps you understand the history of each resource.
+**Origin is informational only** - it doesn't affect drift detection or other operations. It helps you understand how each resource entered state. (Re-applying an `observed` resource's exported spec promotes it to `applied`.)
 
 ## Updating State
 
 State is automatically updated when you:
 
-1. **Apply a configuration** - Updates state with new configuration
-2. **Take a snapshot** - Updates state with current VBR configuration
-3. **Adopt a resource** - Adds resource to state with current configuration
+1. **Apply a configuration** - Updates state with new configuration (origin: `applied`)
+2. **Take a snapshot** - Updates state with current VBR configuration (origin: `observed`)
 
 **Manual state updates:**
 To refresh state for all resources:
@@ -533,11 +523,8 @@ owlctl encryption kms-snapshot --all
 
 **Solution:**
 ```bash
-# Snapshot the resource first
+# Snapshot the resource first to record it in state
 owlctl repo snapshot "Resource Name"
-
-# Or adopt existing resource
-owlctl repo adopt "Resource Name"
 
 # Then diff will work
 owlctl repo diff "Resource Name"
@@ -627,18 +614,16 @@ owlctl repo snapshot --all
 owlctl repo diff --all
 ```
 
-### 4. Use Adopt for Existing Resources
+### 4. Snapshot Existing Resources First
 
-When starting declarative management, adopt existing resources:
+When starting declarative management, snapshot existing resources to seed state (origin: `observed`), then export and apply the ones you want to manage:
 ```bash
-# Adopt all existing resources
-owlctl repo adopt --all
-owlctl repo sobr-adopt --all
-owlctl encryption kms-adopt --all
+# Capture all existing resources into state (monitor-only baseline)
+owlctl snapshot --all
 
 # Commit initial state
 git add state.json
-git commit -m "Adopt existing VBR resources into declarative management"
+git commit -m "Capture existing VBR resources into declarative state"
 git push
 ```
 

--- a/docs/state-management.md
+++ b/docs/state-management.md
@@ -618,8 +618,9 @@ owlctl repo diff --all
 
 When starting declarative management, snapshot existing resources to seed state (origin: `observed`), then export and apply the ones you want to manage:
 ```bash
-# Capture all existing resources into state (monitor-only baseline)
-owlctl snapshot --all
+# Capture existing resources into state (monitor-only baseline)
+owlctl snapshot --all          # repos, SOBRs, encryption, KMS, config backup
+owlctl job snapshot --all      # jobs are excluded from the global snapshot
 
 # Commit initial state
 git add state.json

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -299,7 +299,7 @@ owlctl login
 Edit `settings.json`:
 ```json
 {
-  "skipTLSVerify": true
+  "apiNotSecure": true
 }
 ```
 
@@ -508,11 +508,8 @@ ls -la $OWLCTL_SETTINGS_PATH/state.json
 
 **Solution:**
 ```bash
-# Snapshot the resource first
+# Snapshot the resource first to record it in state
 owlctl repo snapshot "Resource Name"
-
-# Or adopt existing resource
-owlctl repo adopt "Resource Name"
 
 # Then diff will work
 owlctl repo diff "Resource Name"
@@ -849,7 +846,7 @@ $env:OWLCTL_URL
 **Solutions:**
 ```bash
 # Check for typos
-env | grep VCLI
+env | grep OWLCTL
 
 # Ensure no spaces around =
 export OWLCTL_USERNAME="admin"  # Correct
@@ -967,7 +964,7 @@ If you can't find a solution here:
 owlctl utils  # Select "Check Version"
 
 # Environment
-env | grep VCLI
+env | grep OWLCTL
 
 # Profile info
 owlctl profile --get

--- a/examples/README.md
+++ b/examples/README.md
@@ -6,7 +6,7 @@ This directory contains example configurations for owlctl's declarative manageme
 
 ```
 examples/
-├── owlctl.yaml                  # Groups, targets — main config
+├── owlctl.yaml                  # Groups, instances — main config
 ├── profiles/
 │   ├── standard-db-backup.yaml  # kind: Profile — database defaults
 │   └── standard-file-backup.yaml  # kind: Profile — file server defaults
@@ -50,11 +50,15 @@ groups:
     specs:
       - specs/file-backup.yaml
 
-targets:
+instances:
   primary:
-    url: https://vbr-prod.example.com
+    product: vbr
+    url: vbr-prod.example.com    # hostname/IP only — no scheme, no port
+    credentialRef: PROD          # reads OWLCTL_PROD_USERNAME / OWLCTL_PROD_PASSWORD
   dr:
-    url: https://vbr-dr.example.com
+    product: vbr
+    url: vbr-dr.example.com
+    credentialRef: DR
 ```
 
 ### How It Works
@@ -112,11 +116,11 @@ owlctl group show db-tier
 owlctl job apply --group db-tier --dry-run
 owlctl job apply --group db-tier
 
-# Apply to a specific VBR target
-owlctl job apply --group db-tier --target primary
+# Apply to a specific VBR instance (overrides the group's pinned instance)
+owlctl --instance primary job apply --group db-tier
 
 # Drift check a group
-owlctl job diff --group db-tier --target primary
+owlctl --instance primary job diff --group db-tier
 ```
 
 ---

--- a/examples/owlctl.yaml
+++ b/examples/owlctl.yaml
@@ -4,13 +4,33 @@
 apiVersion: owlctl.veeam.com/v1
 kind: Config
 
+# Instances define named VBR server connections.
+# Credentials are read from environment variables (never stored here):
+#   credentialRef: PROD  ->  OWLCTL_PROD_USERNAME / OWLCTL_PROD_PASSWORD
+#   (omit credentialRef to fall back to OWLCTL_USERNAME / OWLCTL_PASSWORD)
+# Switch with the global flag: owlctl --instance primary job apply --group db-tier
+instances:
+  primary:
+    product: vbr
+    url: vbr-prod.example.com        # hostname/IP only — no scheme, no port
+    credentialRef: PROD
+    description: Production VBR server
+
+  dr:
+    product: vbr
+    url: vbr-dr.example.com
+    credentialRef: DR
+    description: Disaster recovery site
+
 # Groups bundle specs with a shared profile and overlay for batch operations.
+# A group may pin an instance (auto-activated on apply/diff) and/or a specsDir.
 # Apply a group: owlctl job apply --group db-tier
 # Diff a group:  owlctl job diff --group db-tier
 groups:
   db-tier:
     description: Database backups — encrypted, 14-day retention, SQL guest processing
-    profile: profiles/standard-db-backup.yaml      # kind: Profile — base defaults
+    instance: primary                               # auto-activates the primary instance
+    profile: profiles/standard-db-backup.yaml       # kind: Profile — base defaults
     overlay: overlays/enable-encryption.yaml        # kind: Overlay — policy patch
     specs:
       - specs/sql-daily.yaml
@@ -21,36 +41,26 @@ groups:
     specs:
       - specs/file-backup.yaml
 
-# Targets define named VBR server connections.
-# Use --target to switch: owlctl job apply --group db-tier --target primary
-targets:
-  primary:
-    url: https://vbr-prod.example.com
-    description: Production VBR server
-
-  dr:
-    url: https://vbr-dr.example.com
-    description: Disaster recovery site
-
 # Usage Examples:
 #
-# 1. List groups and targets
+# 1. List groups and instances
 #    owlctl group list
-#    owlctl target list
+#    owlctl instance list
 #
-# 2. Show group details (resolved paths, spec count)
+# 2. Show group / instance details (resolved paths, spec count)
 #    owlctl group show db-tier
+#    owlctl instance show primary
 #
-# 3. Apply a group (dry-run first)
+# 3. Apply a group (dry-run first) — uses the group's pinned instance
 #    owlctl job apply --group db-tier --dry-run
 #    owlctl job apply --group db-tier
 #
-# 4. Apply a group to a specific target
-#    owlctl job apply --group db-tier --target primary
-#    owlctl job apply --group db-tier --target dr
+# 4. Override the instance for an apply/diff with the global --instance flag
+#    owlctl --instance primary job apply --group file-tier
+#    owlctl --instance dr job diff --group db-tier
 #
 # 5. Drift check a group
-#    owlctl job diff --group db-tier --target primary
+#    owlctl job diff --group db-tier
 #
 # 6. Single-file overlay (no group needed)
 #    owlctl job apply jobs/database-backup.yaml --overlay overlays/retention-30d.yaml

--- a/examples/pipelines/README.md
+++ b/examples/pipelines/README.md
@@ -42,7 +42,7 @@ Create a Variable Group named `veeam-credentials` in your Azure DevOps project:
 4. Add variables:
    - `OWLCTL_USERNAME` - VBR API username
    - `OWLCTL_PASSWORD` - VBR API password (mark as **secret**)
-   - `OWLCTL_URL` - VBR server URL (e.g., `https://vbr.example.com:9419`)
+   - `OWLCTL_URL` - VBR hostname or IP only, no scheme or port (e.g., `vbr.example.com`)
 5. (Optional) `SLACK_WEBHOOK_URL` for notifications
 
 **Security note:** Use Azure Key Vault linked Variable Groups for production environments.
@@ -379,7 +379,7 @@ rules:
 Error: failed to login
 ```
 
-- Verify `OWLCTL_URL` includes port (e.g., `https://vbr:9419`)
+- Verify `OWLCTL_URL` is the hostname/IP only — no scheme or port (e.g., `vbr.example.com`, not `https://vbr:9419`)
 - Check username format (may need `DOMAIN\user`)
 - Ensure VBR REST API is enabled
 
@@ -390,7 +390,7 @@ Error: resource 'X' not found in VBR (update-only mode)
 ```
 
 - Resource was deleted from VBR
-- Must recreate in VBR console, then re-adopt
+- Must recreate in VBR console, then re-apply the exported spec
 
 ### TLS Certificate Errors
 
@@ -419,11 +419,11 @@ Import-Certificate -FilePath vbr-ca.crt -CertStoreLocation Cert:\LocalMachine\Ro
 
 **Option 2: Skip TLS verification (not recommended for production)**
 
-Set `skipTLSVerify: true` in settings.json. This bypasses certificate validation entirely and should only be used for testing.
+Set `apiNotSecure: true` in settings.json. This bypasses certificate validation entirely and should only be used for testing.
 
 ```json
 {
-  "skipTLSVerify": true,
+  "apiNotSecure": true,
   "credsFileMode": false
 }
 ```

--- a/state/models.go
+++ b/state/models.go
@@ -29,7 +29,7 @@ type State struct {
 
 // ResourceEvent represents an action taken on a resource
 type ResourceEvent struct {
-	Action    string    `json:"action"`           // "snapshotted", "adopted", "applied", "created"
+	Action    string    `json:"action"`           // "snapshotted", "applied", "created"
 	Timestamp time.Time `json:"timestamp"`        // When the action occurred
 	User      string    `json:"user"`             // Who performed the action
 	Fields    []string  `json:"fields,omitempty"` // Fields that were changed (for apply/created)


### PR DESCRIPTION
## Summary

Phase 1 of a documentation overhaul: a **correctness sweep** that fixes stale/incorrect docs and examples, plus a **real CLI bug** it surfaced along the way. Scoped to factual corrections only — no restructuring (front-door consolidation, de-duplication, and `docs/internal/` cleanup are queued as later phases).

> Stacked on `feat/global-export-snapshot` so this diff shows only the Phase 1 changes. Retarget to `master` once that branch lands.

## The bug this surfaced

The `adopt` command (`owlctl repo adopt`, `job adopt`, etc.) **never existed** — there's no such cobra command, and the only state origins any code writes are `applied` and `observed`. But the shipping CLI's *own runtime output* told users to run it:
- the `observed`/not-found remediation guidance in `apply_reporting.go`
- five `diff` summary lines ("drifted (observed) — adopt to enable remediation")

A user following owlctl's guidance hit `unknown command "adopt"`. Reconciled in both code and docs to the real flow: `export` → `apply` to manage, `snapshot` to monitor-only (and read-only encryption passwords now get an honest "remediate manually" message).

## Documentation / examples
- Correct state origin values to `applied`/`observed`; remove fictional `adopted`/`exported`/`snapshot` origins
- `skipTLSVerify` → `apiNotSecure` (the real settings key) — **8 occurrences** across 5 files
- Stale `VCLI_*` env vars → `OWLCTL_*`
- Examples migrated from deprecated `targets:`/`--target` to `instances:`/`--instance` with hostname-only URLs
- Fix `OWLCTL_URL` guidance — it must be hostname-only; the documented `https://host:9419` form built a broken double-scheme connection string
- Add the missing `state list/show/history/path` command group to the command reference
- Rewrite the phantom "Adopt Commands" section as the real export→apply flow; correct the "no job snapshot command" claim (it exists)

## Code
- `apply_reporting.go`: rename `AdoptCmd` → `ManageCmd`, point at real apply commands, honest read-only message for encryption, fix dead `printNotFoundGuidance` text
- `repo.go` / `jobs.go` / `encryption.go`: diff-summary strings now point at the real export→apply guidance
- `state/models.go`: drop vestigial `"adopted"` history action from a comment

## Testing
- `go build` clean
- `go test ./...` green

🤖 Generated with [Claude Code](https://claude.com/claude-code)