### PR TITLE
Docs Phase 3b: fix the orphaned/colliding GitOps conceptual doc

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -376,6 +376,7 @@ groups:
 - `docs/security-alerting.md` - Value-aware severity reference
 - `docs/imperative-mode.md` - GET/POST/PUT operations, output formatting
 - `docs/authentication.md` - Credentials, token storage, multi-product
+- `docs/gitops-for-backup-infrastructure.md` - Conceptual case for GitOps (the "why")
 - `docs/gitops-workflows.md` - GitHub Actions, Azure DevOps, GitLab CI
 - `docs/azure-devops-integration.md` - CI/CD integration guide
 - `docs/troubleshooting.md` - Common issues and fixes

--- a/README.md
+++ b/README.md
@@ -126,6 +126,7 @@ export OWLCTL_URL="vbr.example.com"
 | [Drift Detection](docs/drift-detection.md) | Severity classification, filtering, exit codes |
 | [Security Alerting](docs/security-alerting.md) | Value-aware severity reference, cross-resource validation |
 | [Imperative Mode](docs/imperative-mode.md) | GET/POST/PUT API operations, output formatting |
+| [Why GitOps](docs/gitops-for-backup-infrastructure.md) | The conceptual case for managing backup infrastructure as code |
 | [GitOps Workflows](docs/gitops-workflows.md) | GitHub Actions, Azure DevOps, GitLab CI integration |
 | [Azure DevOps Integration](docs/azure-devops-integration.md) | Pipeline templates, scheduled scans, PR validation |
 | [Authentication](docs/authentication.md) | Credentials, token storage, multi-product switching |

--- a/docs/gitops-for-backup-infrastructure.md
+++ b/docs/gitops-for-backup-infrastructure.md
@@ -1,4 +1,6 @@
-# GitOps for Backup Infrastructure: Using Veeam APIs with Azure DevOps
+# Why GitOps for Backup Infrastructure
+
+> **This is the conceptual guide** — the case for managing Veeam backup infrastructure as code and how owlctl fits the wider infrastructure-as-code ecosystem. For hands-on setup, see the [GitOps Workflows Guide](gitops-workflows.md) (GitHub Actions, Azure DevOps, GitLab CI) and the [Azure DevOps Integration Guide](azure-devops-integration.md). Ready-to-use pipelines live in [`examples/pipelines/`](../examples/pipelines/).
 
 ## Executive Summary
 

--- a/docs/gitops-for-backup-infrastructure.md
+++ b/docs/gitops-for-backup-infrastructure.md
@@ -1,6 +1,6 @@
 # Why GitOps for Backup Infrastructure
 
-> **This is the conceptual guide** — the case for managing Veeam backup infrastructure as code and how owlctl fits the wider infrastructure-as-code ecosystem. For hands-on setup, see the [GitOps Workflows Guide](gitops-workflows.md) (GitHub Actions, Azure DevOps, GitLab CI) and the [Azure DevOps Integration Guide](azure-devops-integration.md). Ready-to-use pipelines live in [`examples/pipelines/`](../examples/pipelines/).
+> **This is the conceptual guide** — the case for managing Veeam backup infrastructure as code and how owlctl fits the wider infrastructure-as-code ecosystem. For hands-on setup, see the [GitOps Workflows Guide](gitops-workflows.md) (GitHub Actions, Azure DevOps, GitLab CI) and the [Azure DevOps Integration Guide](azure-devops-integration.md). Ready-to-use **Azure DevOps** pipeline templates live in [`examples/pipelines/`](../examples/pipelines/).
 
 ## Executive Summary
 

--- a/docs/gitops-workflows.md
+++ b/docs/gitops-workflows.md
@@ -1757,6 +1757,7 @@ jobs:
 
 ## See Also
 
+- [Why GitOps for Backup Infrastructure](gitops-for-backup-infrastructure.md) - The conceptual case for this approach
 - [Getting Started Guide](getting-started.md) - Basic owlctl setup
 - [Declarative Mode Guide](declarative-mode.md) - Declarative commands reference
 - [Azure DevOps Integration](azure-devops-integration.md) - Detailed Azure DevOps guide

--- a/docs/gitops-workflows.md
+++ b/docs/gitops-workflows.md
@@ -1764,7 +1764,7 @@ jobs:
 - [Drift Detection Guide](drift-detection.md) - Comprehensive drift detection
 - [Security Alerting](security-alerting.md) - Severity classification reference
 - [State Management](state-management.md) - State file deep dive
-- [Pipeline Examples](../examples/pipelines/) - Ready-to-use pipeline templates
+- [Pipeline Examples](../examples/pipelines/) - Ready-to-use Azure DevOps pipeline templates
 
 ---
 


### PR DESCRIPTION
## Summary

Phase 3b of the documentation overhaul: de-duplicate / disambiguate the GitOps cluster. The standalone fix here is the conceptual doc.

Stacked on #157 (Phase 3a). Retarget down the stack as earlier PRs land.

## The problem

`gitops-for-backup-infrastructure.md` was an **orphan** — nothing in the docs, README, or CLAUDE.md linked to it — and its title (*"GitOps for Backup Infrastructure: Using Veeam APIs with Azure DevOps"*) **collided** with `azure-devops-integration.md`, so a reader scanning the docs couldn't tell the conceptual essay from the practical ADO guide.

## Changes

- Retitled its H1 to **"Why GitOps for Backup Infrastructure"** and added an orientation blockquote pointing to the practical guides and `examples/pipelines/`.
- Added inbound links so it's discoverable: `gitops-workflows.md` **See Also**, the **README** docs table, and **CLAUDE.md**'s docs list.

The three GitOps docs now have distinct, signposted roles:
| Doc | Role |
|-----|------|
| `gitops-for-backup-infrastructure.md` | The conceptual "why" |
| `gitops-workflows.md` | Multi-platform how-to (GitHub / ADO / GitLab) |
| `azure-devops-integration.md` | ADO deep dive |

## Scope note — embedded pipelines deferred

The audit also flagged pipeline YAML embedded in the docs vs. living in `examples/pipelines/`. I deliberately left that for a separate change because it's narrower and riskier than it first looks:
- The **GitHub Actions and GitLab** pipelines in `gitops-workflows.md` are the *only* copy (examples/ is ADO-only) — **not** duplicates; they must stay.
- Only the **ADO** pipelines duplicate `examples/pipelines/`, and `azure-devops-integration.md` already declares examples/ the canonical source (Quick Start table). Replacing the inline ADO pipelines safely needs per-pipeline equivalence checks — better done deliberately as its own PR than bundled here.

Docs-only; no code changes. Verified the conceptual doc's inbound/outbound links all resolve.

🤖 Generated with [Claude Code](https://claude.com/claude-code)